### PR TITLE
Travis deploy to staging on merge to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ jobs:
 stages:
   - name: "Install and run integration tests"
   - name: "Deploy to Staging"
-    if: (branch = master) AND (type = pull_request)
-  - name: "Deploy to Production"
     if: (branch = master) AND (type = push)
+  - name: "Deploy to Production"
+    if: (branch = prod) AND (type = push)


### PR DESCRIPTION
In an effort to streamline front-end development, staging deploys on merge to `master`. Prod deploys on merge to branch `prod`

I want to switch clients to use staging backend

We should only merge to `prod` branch from `master` branch, after we ensure dev clients are operating as expected