### PR TITLE
Create api-ubcbiztech.com domain, fix PROD memberships table access

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -152,11 +152,15 @@ export default {
 
     const docClient = new AWS.DynamoDB.DocumentClient();
 
+    if (table !== 'biztechMemberships2021') {
+      table = table + process.env.ENIRONMENT;
+    }
+
     try {
 
       // construct the param object
       const params = {
-        TableName: table + process.env.ENVIRONMENT,
+        TableName: table,
         ...filters
       };
 

--- a/serverless.common.yml
+++ b/serverless.common.yml
@@ -14,11 +14,18 @@ custom:
     # use test template to overwrite plugin usage of commonjs
     testTemplate: ../../lib/testTemplate.ejs
 
+  stage: ${opt:stage, self:provider.stage}
+
+  domains:
+    prod: api.ubcbiztech.com
+    staging: api-staging.ubcbiztech.com
+    dev: api-dev.ubcbiztech.com
+
   customDomain:
-    domainName: api-${self:provider.stage}.ubcbiztech.com
+    domainName: ${self:custom.domains.${self:custom.stage}}
     basePath: ''
     stage: ${self:provider.stage}
-    certificateName: 'api-${self:provider.stage}.ubcbiztech.com'
+    certificateName: ${self:custom.domains.${self:custom.stage}}
     createRoute53Record: true
     endpointType: 'edge'
     apiType: rest

--- a/services/memberships/serverless.yml
+++ b/services/memberships/serverless.yml
@@ -25,8 +25,9 @@ provider:
     - Effect: Allow
       Action:
         - dynamodb:Scan
+        - dynamodb:GetItem
       Resource:
-        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMemberships2021${self:provider.environment.ENVIRONMENT}"
+        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMemberships2021"
 
 
 custom: ${file(../../serverless.common.yml):custom}


### PR DESCRIPTION
🎟️ **Ticket(s):**
Closes #

👷 **Changes:**
- `serverless.common.yml` now refers to defined urls for different stages
- memberships GET was trying to access `biztechMemberships2021PROD` which doesn't exist, put in a check since all other services use `biztech{SERVICE}PROD`

💭 **Notes:**
Any additional things to take into consideration.

**Wait! Before you merge, have you checked the following:**
- [ ] Serverless tests are passing (Check travis build logs, CI is currently broken)
- [ ] PR is has approving review(s)
