### PR TITLE
Event Create - match question fields to frontend

### DIFF
--- a/services/events/handler.js
+++ b/services/events/handler.js
@@ -37,9 +37,12 @@ export const create = async (event, ctx, callback) => {
       latitude: data.latitude,
       createdAt: timestamp,
       updatedAt: timestamp,
-      textFields: data.textFields,
-      selectFields: data.selectFields,
-      checkboxFields: data.checkboxFields
+      requiredTextFields: data.requiredTextFields,
+      unrequiredTextFields: data.unrequiredTextFields,
+      requiredSelectFields: data.requiredSelectFields,
+      unrequiredSelectFields: data.unrequiredSelectFields,
+      requiredCheckBoxFields: data.requiredCheckBoxFields,
+      unrequiredCheckBoxFields: data.unrequiredCheckBoxFields,
     };
 
     const res = await db.create(item, EVENTS_TABLE);


### PR DESCRIPTION
🎟️ **Ticket(s):**
Closes #191 (again)

👷 **Changes:**
The front-end PR at https://github.com/ubc-biztech/bt-web/pull/232 stores the custom text/select/checkbox fields added on the exec side into separate fields depending on whether they are required or not. This PR allows these fields to be extracted in the back-end - currently no custom fields are being stored when an exec submits a new event (on the branch of the linked PR)

💭 **Notes:**
Unit and integration tests all pass - no regressions.

**Wait! Before you merge, have you checked the following:**
- [ ] Serverless tests are passing (Check travis build logs, CI is currently broken)
- [ ] PR is has approving review(s)
