### PR TITLE
Relaxed production requirement for event registration confirmation email

### DIFF
--- a/services/registrations/handler.js
+++ b/services/registrations/handler.js
@@ -57,7 +57,7 @@ async function updateHelper(data, createNew, email) {
   // try to send the registration email
   try {
 
-    if(process.env.ENVIRONMENT !== '') await sendEmail(existingUser, existingEvent.ename, registrationStatus);
+    await sendEmail(existingUser, existingEvent.ename, registrationStatus);
 
   }
   catch(err) {


### PR DESCRIPTION
🎟️ **Ticket(s):**
Closes ["Email confirmations are not being sent to users when they register for an event"](https://www.notion.so/ubcbiztech/Email-confirmations-are-not-being-sent-to-users-when-they-register-for-an-event-47cde4268e62415eac8a8518ba060a0c)

👷 **Changes:**
Emails are now being fired off every time a user registers, but if you’re registering for an event on dev/staging and you’re NOT using a [ubcbiztech.com](http://ubcbiztech.com/) email, the confirmation receipt will be sent to dev (at) ubcbiztech.com, not the email that the user signed up with.

💭 **Notes:**
Everything production-side was working before, and should still work. Styling of the SendGrid email could use some work, though.

**Wait! Before you merge, have you checked the following:**
- [ ] Serverless tests are passing (Check travis build logs, CI is currently broken)
- [ ] PR is has approving review(s)
