### PR TITLE
Add feedback form link logic to event

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -567,6 +567,8 @@ components:
           type: string
         imageUrl:
           type: string
+        feedback:
+          type: string
         registrationQuestions:
           type: array
           items:
@@ -624,6 +626,8 @@ components:
           type: string
         imageUrl:
           type: string
+        feedback:
+          type: string
         registrationQuestions:
           type: array
           items:
@@ -666,6 +670,8 @@ components:
         endDate:
           type: string
         imageUrl:
+          type: string
+        feedback:
           type: string
         registrationQuestions:
           type: array

--- a/services/events/handler.js
+++ b/services/events/handler.js
@@ -47,6 +47,7 @@ export const create = async (event, ctx, callback) => {
       requiredCheckBoxFields: data.requiredCheckBoxFields,
       unrequiredCheckBoxFields: data.unrequiredCheckBoxFields,
       isPublished: data.isPublished,
+      feedback: data.feedback,
     };
 
     if (Array.isArray(data.registrationQuestions)) {

--- a/services/events/test/eventCreate.js
+++ b/services/events/test/eventCreate.js
@@ -31,6 +31,7 @@ const eventPayload = {
       required: true,
     }
   ],
+  feedback: 'test-feedback-form-link',
 };
 
 const eventPayloadWithRegistrationQuestionIds = {

--- a/services/events/test/eventUpdate.js
+++ b/services/events/test/eventUpdate.js
@@ -23,7 +23,8 @@ const updatePayload = {
   longitude: -120.00,
   latitude: 78.00,
   createdAt: '20200607T000000-0400',
-  updatedAt: '20200607T000000-0400'
+  updatedAt: '20200607T000000-0400',
+  feedback: 'updated-test-feedback-form-link',
 };
 
 describe('eventUpdate', () => {

--- a/services/events/test_integration/events.js
+++ b/services/events/test_integration/events.js
@@ -141,9 +141,10 @@ describe('events integration', function () {
             required: true,
           }
         ],
+        feedback: 'updated-test-feedback-form-link',
       };
 
-      // fields that are different in the updatePayload: ename, description, capac, elocation, longitude, latitude, registrationQuestions
+      // fields that are different in the updatePayload: ename, description, capac, elocation, longitude, latitude, registrationQuestions, feedback
       const defaultPayload = {
         ename: 'integrationTestEventName',
         description: 'default test event description',
@@ -161,6 +162,7 @@ describe('events integration', function () {
             required: false,
           }
         ],
+        feedback: 'test-feedback-form-link',
       };
 
       it('event PATCH returns 200 on update success', async () => {
@@ -198,6 +200,7 @@ describe('events integration', function () {
             expect(body.capac).to.equal(defaultPayload.capac);
             expect(body.longitude).to.equal(defaultPayload.longitude);
             expect(body.registrationQuestions).to.have.deep.members(defaultPayload.registrationQuestions);
+            expect(body.feedback).to.equal(defaultPayload.feedback);
 
           });
 
@@ -228,6 +231,7 @@ describe('events integration', function () {
             expect(body.capac).to.equal(updatePayload.capac);
             expect(body.longitude).to.equal(updatePayload.longitude);
             expect(body.registrationQuestions).to.have.deep.members(updatePayload.registrationQuestions);
+            expect(body.feedback).to.equal(updatePayload.feedback);
 
           });
 


### PR DESCRIPTION
🎟️ **Ticket(s):**
Closes Feedback Form Link 

👷 **Changes:**
A brief summary of what changes were introduced.
Adds logic to save the feedback form link on the events form to the database

💭 **Notes:**
Any additional things to take into consideration.

**Wait! Before you merge, have you checked the following:**
- [ ] Serverless tests are passing (Check travis build logs, CI is currently broken)
- [ ] PR is has approving review(s)
