### PR TITLE
Make waitlisting default compatible with Stripe

### DIFF
--- a/services/payments/handler.js
+++ b/services/payments/handler.js
@@ -257,10 +257,12 @@ export const webhook = async(event, ctx, callback) => {
 
     try {
 
+      const eventIDAndYear = data.eventID + ';' + data.year;
+
       const body = {
         eventID: data.eventID,
         year: Number(data.year),
-        registrationStatus: 'registered',
+        registrationStatus: eventIDAndYear === 'produhacks;2023' ? 'waitlist' : 'registered',
       };
       await updateHelper(body, false, data.email, data.fname);
       const response = helpers.createResponse(200, {
@@ -360,7 +362,7 @@ export const payment = async (event, ctx, callback) => {
       const body = {
         eventID: data.eventID,
         year: Number(data.year),
-        checkoutLink: session.url,
+        checkoutLink: session.url
       };
       await updateHelper(body, false, data.email, data.fname);
 

--- a/services/registrations/handler.js
+++ b/services/registrations/handler.js
@@ -19,6 +19,9 @@ export async function updateHelper(data, createNew, email, fname) {
   const { eventID, year } = data;
   const eventIDAndYear = eventID + ';' + year;
 
+  console.log(data);
+  console.log('CloudWatch debugging purposes');
+
   // for the QR code, we pass this to SendGrid
   const id = `${email};${eventIDAndYear};${fname}`;
 
@@ -302,14 +305,6 @@ export const post = async (event, ctx, callback) => {
       }
 
     } else {
-
-      const eventIDAndYear = `${data.eventID};${data.year}`;
-      // TODO: this is temporary. please remove after produhacks 2023
-      if (eventIDAndYear === 'produhacks;2023') {
-
-        data.registrationStatus = 'waitlist';
-
-      }
 
       const response = await updateHelper(data, true, data.email, data.fname);
 


### PR DESCRIPTION
🎟️ **Ticket(s):**
The previous fix from #254 did not work for the majority of members on Production as the waitlist status was overridden by the Payments service.

👷 **Changes:**
- moved waitlist default to Payments upon Stripe webhook received (for ProduHacks)
- add console logs if more CloudWatch debugging is needed for ProduHacks

💭 **Notes:**
- CAVEAT: Exec accounts will not be affected by this waitlist behaviour because they aren't going through the Stripe flow. They will default to a 'Registered' status instead
![image](https://user-images.githubusercontent.com/21225415/227077027-c926f923-7a0f-4582-831c-bb7c2d40b2bf.png)

**Wait! Before you merge, have you checked the following:**
- [ ] Serverless tests are passing (Check travis build logs, CI is currently broken)
- [ ] PR is has approving review(s)
