### PR TITLE
restrict users from updating admin in the USER patch endpoint

### DIFF
--- a/constants/tables.js
+++ b/constants/tables.js
@@ -10,4 +10,4 @@ export const USER_REGISTRATIONS_TABLE = "biztechRegistrations";
 export const QRS_TABLE = "biztechQRs";
 export const TEAMS_TABLE = "biztechTeams";
 
-export const IMMUTABLE_USER_PROPS = ["admin"]
+export const IMMUTABLE_USER_PROPS = ["admin"]; // make sure you check all calls to /user's patch in the frontend if you add to this list

--- a/constants/tables.js
+++ b/constants/tables.js
@@ -9,3 +9,5 @@ export const USERS_TABLE = "biztechUsers";
 export const USER_REGISTRATIONS_TABLE = "biztechRegistrations";
 export const QRS_TABLE = "biztechQRs";
 export const TEAMS_TABLE = "biztechTeams";
+
+export const IMMUTABLE_USER_PROPS = ["admin"]

--- a/services/users/handler.js
+++ b/services/users/handler.js
@@ -6,7 +6,7 @@ import {
   isEmpty, isValidEmail
 } from "../../lib/utils";
 import {
-  USERS_TABLE, EVENTS_TABLE
+  USERS_TABLE, EVENTS_TABLE, IMMUTABLE_USER_PROPS
 } from "../../constants/tables";
 
 export const create = async (event, ctx, callback) => {
@@ -199,6 +199,10 @@ export const update = async (event, ctx, callback) => {
     if (isEmpty(existingUser)) throw helpers.notFoundResponse("user", email);
 
     const data = JSON.parse(event.body);
+
+    const invalidUpdates = Object.keys(data).filter((prop) => IMMUTABLE_USER_PROPS.includes(prop));
+    if (invalidUpdates.length > 0) throw helpers.inputError(`Cannot update ${invalidUpdates.join(", ")}`);
+
     const res = await db.updateDB(email, data, USERS_TABLE);
     const response = helpers.createResponse(200, {
       message: `Updated event with email ${email}!`,


### PR DESCRIPTION
🎟️ **Ticket(s):**
Closes # https://www.notion.so/ubcbiztech/b24732925a6745caa305a2c746fa5ba7?v=d557178d0a134acf85a3890882538364&p=dd9baf94e6c6405281ca822b4b45fb13&pm=s

👷 **Changes:**
A brief summary of what changes were introduced.

Temp soln to the backend security.
Problem: anyone is able to access our backend. The most dangerous is if someone changes their user.admin = True. The broader problem is that all our endpoints can be hit using tools like Postman... This makes it so that people can infiltrate our db with injections of data into all our tables. 

This pr just addresses the simple problem of ppl setting admin = True.

💭 **Notes:**
Any additional things to take into consideration.


**Wait! Before you merge, have you checked the following:**
- [ ] Serverless tests are passing (Check travis build logs, CI is currently broken)
- [ ] PR is has approving review(s)
