### PR TITLE
bug fix

### DIFF
--- a/services/registrations/handler.js
+++ b/services/registrations/handler.js
@@ -68,7 +68,9 @@ export async function updateHelper(data, createNew, email, fname) {
   // always check application status first, if not null then we send a application status email, else send regular 
   if (applicationStatus) {
     try {
-      await sendEmail(user, existingEvent, applicationStatus, id, "application");
+      if (!data.isPartner) {
+        await sendEmail(user, existingEvent, applicationStatus, id, "application");
+      }
     } catch (err) {
       // if email sending failed, that user's email probably does not exist
       throw helpers.createResponse(500, {
@@ -106,7 +108,9 @@ export async function updateHelper(data, createNew, email, fname) {
     }
     // try to send the registration and calendar emails 
     try {
-      await sendEmail(user, existingEvent, dynamicRegistrationStatus);
+      if (!data.isPartner) {
+        await sendEmail(user, existingEvent, dynamicRegistrationStatus);
+      }
     } catch (err) {
       // if email sending failed, that user's email probably does not exist
       throw helpers.createResponse(500, {


### PR DESCRIPTION
🎟️ **Ticket(s):**
Closes #

👷 **Changes:**
Bug: Currently, we send an email to non partners by doing a query to the db to find that registration and see if isPartner is true. However, upon registration, the partner data is not present in the db, so isPartner is null. We should do a check before sending emails to see if it isPartner to ensure no emails are sent **when partners register**. The old functionality ensures that when we are changing the status in the stats table, no emails are sent as the isPartner field is not sent to the backend when we toggle the statuses manually in the stats table. 

💭 **Notes:**
Any additional things to take into consideration.

**Wait! Before you merge, have you checked the following:**
- [ ] Serverless tests are passing (Check travis build logs, CI is currently broken)
- [ ] PR is has approving review(s)
