### PR TITLE
deauthenticated qr-create so that we can create qrs when registering …

### DIFF
--- a/services/qr/serverless.yml
+++ b/services/qr/serverless.yml
@@ -85,10 +85,6 @@ functions:
           path: qr/
           method: post
           cors: true
-          authorizer:
-            name: ${self:service}-authorizer
-            type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
   qrUpdate:
     handler: handler.update
     events:


### PR DESCRIPTION
…partners while not logged in

🎟️ **Ticket(s):**
Closes #n/a

👷 **Changes:**
A brief summary of what changes were introduced.
Fixes the bug for qr creation on partner sign up where we were getting a error 401 unauthenticated

💭 **Notes:**
Any additional things to take into consideration.

**Wait! Before you merge, have you checked the following:**
- [ ] Serverless tests are passing (Check travis build logs, CI is currently broken)
- [ ] PR is has approving review(s)
