### PR TITLE
Stripe checkout

### DIFF
--- a/services/payments/handler.js
+++ b/services/payments/handler.js
@@ -1,4 +1,4 @@
- import helpers from "../../lib/handlerHelpers";
+import helpers from "../../lib/handlerHelpers";
 import {
   isValidEmail
 } from "../../lib/utils";
@@ -301,22 +301,22 @@ export const webhook = async (event, ctx, callback) => {
     }
 
     switch (data.paymentType) {
-      case "UserMember":
-        await userMemberSignup(data);
-        break;
-      case "OAuthMember":
-        await OAuthMemberSignup(data);
-        break;
-      case "Member":
-        await memberSignup(data);
-        break;
-      case "Event":
-        await eventRegistration(data);
-        break;
-      default:
-        return helpers.createResponse(400, {
-          message: "Webhook Error: unidentified payment type"
-        });
+    case "UserMember":
+      await userMemberSignup(data);
+      break;
+    case "OAuthMember":
+      await OAuthMemberSignup(data);
+      break;
+    case "Member":
+      await memberSignup(data);
+      break;
+    case "Event":
+      await eventRegistration(data);
+      break;
+    default:
+      return helpers.createResponse(400, {
+        message: "Webhook Error: unidentified payment type"
+      });
     }
   } else if (eventData.type === "checkout.session.expired") {
     const data = eventData.data.object.metadata;


### PR DESCRIPTION
🎟️ **Ticket(s):**
Closes #

👷 **Changes:**
Configured session object to enable after expiration actions. Stripe sends event to webhook with new url that gets generated. The new link creates a new Checkout Session that’s a copy of the original expired session.

Flow:

1. Link expires
2. Stripe sends event to webhook that updates db with the new recovery url
3. User clicks payment

What I'm not sure is whether or not the recovery link becomes the new checkout link? Docs says it makes a copy of the same checkout session, so does that mean it uses the same checkout link that was used before? if so, we need to create a new field in the db for expiration_link so that we don't overwrite that checkoutLink field. 

💭 **Notes:**
Any additional things to take into consideration.

**Wait! Before you merge, have you checked the following:**
- [ ] Serverless tests are passing (Check travis build logs, CI is currently broken)
- [ ] PR is has approving review(s)
