### PR TITLE
Remove node_modules caching from Deploy GitHub Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,82 +2,83 @@ name: Deploy on merge
 'on':
   push:
     branches: [ dev, master ]
-
 jobs:
- deploy:
-   runs-on: ubuntu-latest
-   steps:
-   - uses: actions/checkout@v2
-   - name: Use Node.js ${{ matrix.node-version }}
-     uses: actions/setup-node@v1
-     with:
-       node-version: '18.x'
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: '18.x'
+      
+      # Remove this cache step as we're going to clean node_modules for Node 18 upgrade #355
+      # - name: Cache node modules
+      #   uses: actions/cache@v2
+      #   env:
+      #     cache-name: cache-node-modules
+      #   with:
+      #     path: ~/.npm
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
 
-   # https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows
-   - name: Cache node modules
-     uses: actions/cache@v2
-     env:
-       cache-name: cache-node-modules
-     with:
-     # npm cache files are stored in `~/.npm` on Linux/macOS
-       path: ~/.npm
-       key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-       restore-keys: |
-         ${{ runner.os }}-build-${{ env.cache-name }}-
-         ${{ runner.os }}-build-
-         ${{ runner.os }}-
+      - name: Clean install dependencies
+        run: |
+          rm -rf node_modules
+          npm ci
+      
+      - name: Install Serverless CLI
+        run: sudo npm i -g serverless
+      
+      - name: 'Deploy Dev'
+        if: github.ref == 'refs/heads/dev'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
+          SENDGRID_KEY: ${{ secrets.SENDGRID_KEY }}
+          STRIPE_DEV_CANCEL: ${{ secrets.STRIPE_DEV_CANCEL }}
+          STRIPE_DEV_ENDPOINT: ${{ secrets.STRIPE_DEV_ENDPOINT }}
+          STRIPE_PROD_CANCEL: ${{ secrets.STRIPE_PROD_CANCEL }}
+          STRIPE_PROD_ENDPOINT: ${{ secrets.STRIPE_PROD_ENDPOINT }}
+          STRIPE_PROD_KEY: ${{ secrets.STRIPE_PROD_KEY}}
+          STRIPE_DEV_KEY: ${{ secrets.STRIPE_DEV_KEY}}
+        run: |
+          cd services
+          for DIR in *; do
+            (cd $DIR && sls deploy --conceal \
+              --STRIPE_DEV_CANCEL ${{ secrets.STRIPE_DEV_CANCEL }} \
+              --STRIPE_DEV_ENDPOINT ${{ secrets.STRIPE_DEV_ENDPOINT }} \
+              --STRIPE_PROD_CANCEL ${{ secrets.STRIPE_PROD_CANCEL }} \
+              --STRIPE_PROD_ENDPOINT ${{ secrets.STRIPE_PROD_ENDPOINT }} \
+              --STRIPE_PROD_KEY ${{ secrets.STRIPE_PROD_KEY }} \
+              --STRIPE_DEV_KEY ${{ secrets.STRIPE_DEV_KEY }} \
+            && cd ..) & done; wait
 
-   - name: Install Serverless CLI and dependencies
-     run: |
-       sudo npm i -g serverless
-       npm ci
-
-   - name: 'Deploy Dev'
-     if: github.ref == 'refs/heads/dev'
-     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
-      SENDGRID_KEY: ${{ secrets.SENDGRID_KEY }}
-      STRIPE_DEV_CANCEL: ${{ secrets.STRIPE_DEV_CANCEL }}
-      STRIPE_DEV_ENDPOINT: ${{ secrets.STRIPE_DEV_ENDPOINT }}
-      STRIPE_PROD_CANCEL: ${{ secrets.STRIPE_PROD_CANCEL }}
-      STRIPE_PROD_ENDPOINT: ${{ secrets.STRIPE_PROD_ENDPOINT }}
-      STRIPE_PROD_KEY: ${{ secrets.STRIPE_PROD_KEY}}
-      STRIPE_DEV_KEY: ${{ secrets.STRIPE_DEV_KEY}}
-     run: |
-      cd services
-      for DIR in *; do
-       (cd $DIR && sls deploy --conceal \
-         --STRIPE_DEV_CANCEL ${{ secrets.STRIPE_DEV_CANCEL }} \
-         --STRIPE_DEV_ENDPOINT ${{ secrets.STRIPE_DEV_ENDPOINT }} \
-         --STRIPE_PROD_CANCEL ${{ secrets.STRIPE_PROD_CANCEL }} \
-         --STRIPE_PROD_ENDPOINT ${{ secrets.STRIPE_PROD_ENDPOINT }} \
-         --STRIPE_PROD_KEY ${{ secrets.STRIPE_PROD_KEY }} \
-         --STRIPE_DEV_KEY ${{ secrets.STRIPE_DEV_KEY }} \
-         && cd ..) & done; wait
-
-   - name: 'Deploy Prod'
-     if: github.ref == 'refs/heads/master'
-     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
-      SENDGRID_KEY: ${{ secrets.SENDGRID_KEY }}
-      STRIPE_DEV_CANCEL: ${{ secrets.STRIPE_DEV_CANCEL }}
-      STRIPE_DEV_ENDPOINT: ${{ secrets.STRIPE_DEV_ENDPOINT }}
-      STRIPE_PROD_CANCEL: ${{ secrets.STRIPE_PROD_CANCEL }}
-      STRIPE_PROD_ENDPOINT: ${{ secrets.STRIPE_PROD_ENDPOINT }}
-      STRIPE_PROD_KEY: ${{ secrets.STRIPE_PROD_KEY}}
-      STRIPE_DEV_KEY: ${{ secrets.STRIPE_DEV_KEY}}
-     run: |
-      cd services
-      for DIR in *; do
-        (cd $DIR && sls deploy --stage prod --conceal \
-          --STRIPE_DEV_CANCEL ${{ secrets.STRIPE_DEV_CANCEL }} \
-          --STRIPE_DEV_ENDPOINT ${{ secrets.STRIPE_DEV_ENDPOINT }} \
-          --STRIPE_PROD_CANCEL ${{ secrets.STRIPE_PROD_CANCEL }} \
-          --STRIPE_PROD_ENDPOINT ${{ secrets.STRIPE_PROD_ENDPOINT }} \
-          --STRIPE_PROD_KEY ${{ secrets.STRIPE_PROD_KEY }} \
-          --STRIPE_DEV_KEY ${{ secrets.STRIPE_DEV_KEY }} \
-          && cd ..) & done; wait
+      - name: 'Deploy Prod'
+        if: github.ref == 'refs/heads/master'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
+          SENDGRID_KEY: ${{ secrets.SENDGRID_KEY }}
+          STRIPE_DEV_CANCEL: ${{ secrets.STRIPE_DEV_CANCEL }}
+          STRIPE_DEV_ENDPOINT: ${{ secrets.STRIPE_DEV_ENDPOINT }}
+          STRIPE_PROD_CANCEL: ${{ secrets.STRIPE_PROD_CANCEL }}
+          STRIPE_PROD_ENDPOINT: ${{ secrets.STRIPE_PROD_ENDPOINT }}
+          STRIPE_PROD_KEY: ${{ secrets.STRIPE_PROD_KEY}}
+          STRIPE_DEV_KEY: ${{ secrets.STRIPE_DEV_KEY}}
+        run: |
+          cd services
+          for DIR in *; do
+            (cd $DIR && sls deploy --stage prod --conceal \
+              --STRIPE_DEV_CANCEL ${{ secrets.STRIPE_DEV_CANCEL }} \
+              --STRIPE_DEV_ENDPOINT ${{ secrets.STRIPE_DEV_ENDPOINT }} \
+              --STRIPE_PROD_CANCEL ${{ secrets.STRIPE_PROD_CANCEL }} \
+              --STRIPE_PROD_ENDPOINT ${{ secrets.STRIPE_PROD_ENDPOINT }} \
+              --STRIPE_PROD_KEY ${{ secrets.STRIPE_PROD_KEY }} \
+              --STRIPE_DEV_KEY ${{ secrets.STRIPE_DEV_KEY }} \
+            && cd ..) & done; wait


### PR DESCRIPTION
### Changes
- Deploy Github Action run fails on #355 for Node 16->18 upgrade because of old, cached dependencies on the GitHub action: https://github.com/ubc-biztech/serverless-biztechapp/actions/runs/9821452731/job/27117142661
- Removing cached dependencies to try to resolve issue

![image](https://github.com/ubc-biztech/serverless-biztechapp/assets/21225415/06e383e4-1e3d-4c39-be3a-89cb967ba582)

