### PR TITLE
Fix sticker responses

### DIFF
--- a/services/stickers/handler.js
+++ b/services/stickers/handler.js
@@ -93,11 +93,6 @@ export const disconnectHandler = async (event, ctx, callback) => {
  *    to sync connection to admin role and state, set id = ADMIN_ROLE
  */
 export const syncHandler = async (event, ctx, callback) => {
-  let test = "nothing changed";
-  if (event.queryStringParameters && event.queryStringParameters.roomID) {
-    test = event.queryStringParameters.roomID;
-  }
-  console.log(test);
   const body = JSON.parse(event.body);
   if (!body.hasOwnProperty("id") || !body.hasOwnProperty("roomID")) {
     const errMessage = checkPayloadProps(body, {

--- a/services/stickers/handler.js
+++ b/services/stickers/handler.js
@@ -111,7 +111,11 @@ export const syncHandler = async (event, ctx, callback) => {
       }
     });
     await sendMessage(event, errMessage);
-    return errMessage;
+    delete errMessage.status;
+    return {
+      statusCode: 406,
+      ...errMessage
+    };
   }
 
   const roomID = body.roomID;
@@ -175,7 +179,11 @@ export const adminHandler = async (event, ctx, callback) => {
       }
     });
     await sendMessage(event, errMessage);
-    return errMessage;
+    delete errMessage.status;
+    return {
+      statusCode: 406,
+      ...errMessage
+    };
   }
   const action = body.event;
   const roomID = body.roomID;
@@ -189,7 +197,11 @@ export const adminHandler = async (event, ctx, callback) => {
     });
 
     await sendMessage(event, errMessage);
-    return errMessage;
+    delete errMessage.status;
+    return {
+      statusCode: 406,
+      ...errMessage
+    };
   }
 
   try {
@@ -292,7 +304,11 @@ export const stickerHandler = async (event, ctx, callback) => {
       }
     });
     await sendMessage(event, errMessage);
-    return errMessage;
+    delete errMessage.status;
+    return {
+      statusCode: 406,
+      ...errMessage
+    };
   }
 
   const { id, stickerName, roomID } = body;
@@ -306,7 +322,7 @@ export const stickerHandler = async (event, ctx, callback) => {
       message: "voting is not open"
     });
     return {
-      status: 400
+      statusCode: 400
     };
   }
 
@@ -338,7 +354,7 @@ export const stickerHandler = async (event, ctx, callback) => {
         message: "Already submitted golden sticker."
       });
       return {
-        status: 400,
+        statusCode: 400,
         message: "Golden sticker already exists"
       };
     }
@@ -373,7 +389,7 @@ export const stickerHandler = async (event, ctx, callback) => {
         message: "Failed to create sticker"
       });
       return {
-        status: 500,
+        statusCode: 500,
         message: "Failed to create sticker"
       };
     }
@@ -404,7 +420,7 @@ export const stickerHandler = async (event, ctx, callback) => {
       roomID
     );
     return {
-      status: 200,
+      statusCode: 200,
       message: stickerName + " sticker created successfully"
     };
   }
@@ -426,7 +442,7 @@ export const stickerHandler = async (event, ctx, callback) => {
       message: "Used up all " + sticker.limit + " stickers"
     });
     return {
-      status: 400
+      statusCode: 400
     };
   }
 
@@ -449,7 +465,7 @@ export const stickerHandler = async (event, ctx, callback) => {
     data: sticker
   });
   return {
-    status: 200
+    statusCode: 200
   };
 };
 
@@ -491,7 +507,11 @@ export const scoreHandler = async (event, ctx, callback) => {
       }
     });
     await sendMessage(event, errMessage);
-    return errMessage;
+    delete errMessage.status;
+    return {
+      statusCode: 406,
+      ...errMessage
+    };
   }
 
   const { id, score, roomID } = body;
@@ -523,7 +543,7 @@ export const scoreHandler = async (event, ctx, callback) => {
     message: "Stored score"
   });
   return {
-    status: 200,
+    statusCode: 200,
     action: ACTION_TYPES.score,
     message: "Stored score"
   };

--- a/services/stickers/helpers.js
+++ b/services/stickers/helpers.js
@@ -1,18 +1,30 @@
-import { ApiGatewayManagementApi } from "@aws-sdk/client-apigatewaymanagementapi";
+import {
+  ApiGatewayManagementApi
+} from "@aws-sdk/client-apigatewaymanagementapi";
 import db from "../../lib/db";
-import { SOCKETS_TABLE, STICKERS_TABLE } from "../../constants/tables";
-import { DeleteCommand, GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  SOCKETS_TABLE, STICKERS_TABLE
+} from "../../constants/tables";
+import {
+  DeleteCommand, GetCommand, QueryCommand
+} from "@aws-sdk/lib-dynamodb";
 import docClient from "../../lib/docClient";
-import { RESERVED_WORDS } from "../../constants/dynamodb";
+import {
+  RESERVED_WORDS
+} from "../../constants/dynamodb";
 import error from "copy-dynamodb-table/error";
-import { ACTION_TYPES, STATE_KEY } from "./constants";
+import {
+  ACTION_TYPES, STATE_KEY
+} from "./constants";
 
 /**
  * @param event socket action event
  * @param {Object} data message object being sent
  */
 export const sendMessage = async (event, data) => {
-  const { url, connectionId } = getEndpoint(event);
+  const {
+    url, connectionId
+  } = getEndpoint(event);
   try {
     let apigatewaymanagementapi = new ApiGatewayManagementApi({
       apiVersion: "2018-11-29",
@@ -230,7 +242,8 @@ export async function notifyAdmins(data, action, event, roomID) {
 export function createUpdateExpression(obj) {
   let val = 0;
   let updateExpression = "SET ";
-  let expressionAttributeValues = {};
+  let expressionAttributeValues = {
+  };
   let expressionAttributeNames = null;
 
   for (const key in obj) {
@@ -238,7 +251,8 @@ export function createUpdateExpression(obj) {
       if (RESERVED_WORDS.includes(key.toUpperCase())) {
         updateExpression += `#v${val} = :val${val},`;
         expressionAttributeValues[`:val${val}`] = obj[key];
-        if (!expressionAttributeNames) expressionAttributeNames = {};
+        if (!expressionAttributeNames) expressionAttributeNames = {
+        };
         expressionAttributeNames[`#v${val}`] = key;
         val++;
       } else {
@@ -263,7 +277,8 @@ export function createUpdateExpression(obj) {
  *
  * return custom error message
  */
-export function checkPayloadProps(payload, check = {}) {
+export function checkPayloadProps(payload, check = {
+}) {
   try {
     const criteria = Object.entries(check);
     criteria.forEach(([key, crit]) => {

--- a/services/stickers/helpers.js
+++ b/services/stickers/helpers.js
@@ -1,31 +1,18 @@
-import {
-  ApiGatewayManagementApi
-} from "@aws-sdk/client-apigatewaymanagementapi";
+import { ApiGatewayManagementApi } from "@aws-sdk/client-apigatewaymanagementapi";
 import db from "../../lib/db";
-import {
-  SOCKETS_TABLE, STICKERS_TABLE
-} from "../../constants/tables";
-import {
-  DeleteCommand, GetCommand, QueryCommand
-} from "@aws-sdk/lib-dynamodb";
+import { SOCKETS_TABLE, STICKERS_TABLE } from "../../constants/tables";
+import { DeleteCommand, GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import docClient from "../../lib/docClient";
-import {
-  RESERVED_WORDS
-} from "../../constants/dynamodb";
+import { RESERVED_WORDS } from "../../constants/dynamodb";
 import error from "copy-dynamodb-table/error";
-import {
-  ACTION_TYPES, STATE_KEY
-} from "./constants";
+import { ACTION_TYPES, STATE_KEY } from "./constants";
 
 /**
  * @param event socket action event
  * @param {Object} data message object being sent
  */
 export const sendMessage = async (event, data) => {
-  const {
-    url, connectionId
-  } = getEndpoint(event);
-
+  const { url, connectionId } = getEndpoint(event);
   try {
     let apigatewaymanagementapi = new ApiGatewayManagementApi({
       apiVersion: "2018-11-29",
@@ -243,8 +230,7 @@ export async function notifyAdmins(data, action, event, roomID) {
 export function createUpdateExpression(obj) {
   let val = 0;
   let updateExpression = "SET ";
-  let expressionAttributeValues = {
-  };
+  let expressionAttributeValues = {};
   let expressionAttributeNames = null;
 
   for (const key in obj) {
@@ -252,8 +238,7 @@ export function createUpdateExpression(obj) {
       if (RESERVED_WORDS.includes(key.toUpperCase())) {
         updateExpression += `#v${val} = :val${val},`;
         expressionAttributeValues[`:val${val}`] = obj[key];
-        if (!expressionAttributeNames) expressionAttributeNames = {
-        };
+        if (!expressionAttributeNames) expressionAttributeNames = {};
         expressionAttributeNames[`#v${val}`] = key;
         val++;
       } else {
@@ -278,8 +263,7 @@ export function createUpdateExpression(obj) {
  *
  * return custom error message
  */
-export function checkPayloadProps(payload, check = {
-}) {
+export function checkPayloadProps(payload, check = {}) {
   try {
     const criteria = Object.entries(check);
     criteria.forEach(([key, crit]) => {


### PR DESCRIPTION
👷 **Changes:**
- fixed handler responses to use statusCode instead of status, internal server errors resolved on prod
- modified errMessage return to work as intended instead of unexpected internal server error
- standardized websocket response messages ("data" keys within "data" has been modified across all handlers to be simpler to work with on the client side)

💭 **Notes:**
- Returns within a handler doesn't have an effect on websocket messages, but within the PROD environment serverless will complain if statusCode is not present (serverless offline only checks that there is a return). 
