### PR TITLE
Pass Lambda environment to Beacon SNS to determine if PROD

### DIFF
--- a/lib/snsHelper.js
+++ b/lib/snsHelper.js
@@ -9,7 +9,13 @@ const snsClient = new SNSClient({
 export async function sendSNSNotification(message, topicArn = process.env.SNS_TOPIC_ARN) {
   const params = {
     Message: JSON.stringify(message),
-    TopicArn: topicArn
+    TopicArn: topicArn,
+    MessageAttributes: {
+      "Environment": {
+        DataType: "String",
+        StringValue: process.env.ENVIRONMENT || "DEV"
+      }
+    }
   };
 
   try {
@@ -18,6 +24,6 @@ export async function sendSNSNotification(message, topicArn = process.env.SNS_TO
     console.log("SNS notification sent successfully");
   } catch (error) {
     console.error("Error sending SNS notification:", error);
-    throw error; // Rethrow the error so the calling function can handle it if needed
+    throw error;
   }
 }


### PR DESCRIPTION
This prevents dev environment SNS notifications from leaking into #biztech-beacon. #biztech-beacon will only receive PROD related requests going forward. We now have a separate channel called #biztech-beacon-dev

This doesn't fix local-testing from alerting #biztech-beacon-dev but we can probably fix that in a follow-up PR if absolutely needed

### Testing
Manual: https://ubcbiztech202425.slack.com/archives/C07U33MCLBC/p1730269465941129