### PR TITLE
Fix Events service dependency on Registrations helpers

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -273,8 +273,8 @@ export default {
 
       return result.Items || [];
     } catch (err) {
-      console.error("DYNAMO DB ERROR", err);
-      return null;
+      const errorResponse = this.dynamoErrorResponse(err);
+      throw errorResponse;
     }
   }
 };

--- a/services/events/serverless.yml
+++ b/services/events/serverless.yml
@@ -36,9 +36,9 @@ provider:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechEvents${self:provider.environment.ENVIRONMENT}"
     - Effect: Allow
       Action:
-        - dynamodb:Scan
+        - dynamodb:Query
       Resource:
-        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechRegistrations${self:provider.environment.ENVIRONMENT}"
+        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechRegistrations${self:provider.environment.ENVIRONMENT}/index/event-query"
     - Effect: Allow
       Action:
         - dynamodb:BatchGetItem


### PR DESCRIPTION
### Notes
This change fixes the failing call to `/events/[id]/[year]?count=true` endpoint. This endpoint is on the critical path for registrations, so its failure was the reason we had to revert the previous GSI PR attempt. 
- Fix permissions on Events service to access the GSI helper on registrations, now using Query instead of Scan
  - note: There doesn't seem to be an existing dependency on the 'users' queryString that uses the `db.scan`, will look to deprecate this endpoint in another PR.
- Add fail-fast and more logging on CloudWatch for future reference

### Testing
Manual testing on dev environment
