### PR TITLE
Events Service: Use GSI and remove event counts on getAll endpoint

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -123,12 +123,16 @@ export default {
   },
 
   scan: async function (table, filters = {
-  }) {
+  }, indexName = null) {
     try {
       const params = {
         TableName: table + (process.env.ENVIRONMENT || ""),
         ...filters
       };
+
+      if (indexName) {
+        params.IndexName = indexName;
+      }
 
       const items = [];
       let results;
@@ -247,16 +251,29 @@ export default {
     }
   },
 
-  query: async function (table, indexName, keyCondition) {
+  query: async function (table, indexName, keyCondition, filters = {
+  }) {
     try {
       const params = {
         TableName: table + (process.env.ENVIRONMENT || ""),
         KeyConditionExpression: keyCondition.expression,
-        ExpressionAttributeValues: keyCondition.expressionValues
+        ExpressionAttributeValues: {
+          ...keyCondition.expressionValues,
+          ...(filters.ExpressionAttributeValues || {
+          })
+        }
       };
 
-      if (keyCondition.expressionNames) {
-        params.ExpressionAttributeNames = keyCondition.expressionNames;
+      if (keyCondition.expressionNames || filters.ExpressionAttributeNames) {
+        params.ExpressionAttributeNames = {
+          ...keyCondition.expressionNames,
+          ...(filters.ExpressionAttributeNames || {
+          })
+        };
+      }
+
+      if (filters.FilterExpression) {
+        params.FilterExpression = filters.FilterExpression;
       }
 
       if (indexName) {

--- a/services/events/serverless.yml
+++ b/services/events/serverless.yml
@@ -28,12 +28,14 @@ provider:
     - Effect: Allow
       Action:
         - dynamodb:Scan
+        - dynamodb:Query
         - dynamodb:GetItem
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechEvents${self:provider.environment.ENVIRONMENT}"
+        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechEvents${self:provider.environment.ENVIRONMENT}/index/event-overview"
     - Effect: Allow
       Action:
         - dynamodb:Query


### PR DESCRIPTION
### Notes
This PR introduces the use of a GSI (`event-overview`) on the Events table for the `getAll` endpoint to reduce the number of attributes projected during the SCAN operation, aiming to lower DynamoDB RCU usage. Lower RCU typically results in reduced AWS costs and improved latency.

- **Key Changes:**
  - Use the `event-overview` GSI on the Events table with a reduced attribute set.
  - Remove dependency on event counts from `getAll`.
  - Remove the 4-month limit for viewing previous events; now, all events are shown. This has negligible impact on RCU and latency and was implemented per Jay's request.

As part of this change, event count attributes will no longer be added to each event returned by the `getAll` endpoint, as these are only needed for the `get` endpoint. Testing revealed that removing this dependency had the most significant impact on reducing RCU and latency, as it eliminated additional `db.getOne` calls to the Events table and reliance on SCAN operations on the Registrations table for tabulating event registration statuses.

**Note:** Although the SCAN operation was initially converted to a QUERY, the change showed negligible improvement in RCU and latency. We can opt to retain SCAN since the primary RCU and latency issues were resolved by removing event counts, and SCAN ensures all past events are included.

---

### Testing
Manual testing was performed on the dev environment (`bt-web`) with `sls deploy`:
- Admin event pages and attendee event overview pages load as expected.
- No regressions were observed in the event registration form after removing event counts.

**CloudWatch Metrics:**  
Post-change RCUs are expected to be **<1%** of previous RCU usage.

Sample Metrics (dev RCU ≈ prod RCU):  
**Before (stress test on dev):**  
![image](https://github.com/user-attachments/assets/128f2c09-c3e9-45eb-ad87-2ee23536ece3)

**After (stress test on dev):**  
![image](https://github.com/user-attachments/assets/e78127a1-98f4-4f3b-9587-a32754712d81)  