### PR TITLE
Require admin authorization on registrations getAll

### DIFF
--- a/services/registrations/handler.js
+++ b/services/registrations/handler.js
@@ -534,6 +534,14 @@ export const get = async (event, ctx, callback) => {
         );
       }
     } else if (queryString.eventID && queryString.year) {
+      const claims = event.requestContext.authorizer.claims;
+
+      if (!claims || !claims.email || !claims.email.endsWith("@ubcbiztech.com")) {
+        throw helpers.createResponse(403, {
+          message: "Unauthorized: Admin access required"
+        });
+      }
+
       // Query by eventID;year using GSI
       const eventIDYear = `${queryString.eventID};${queryString.year}`;
       const keyCondition = {

--- a/services/registrations/serverless.yml
+++ b/services/registrations/serverless.yml
@@ -88,6 +88,10 @@ functions:
                 email: false
                 afterTimestamp: false
           cors: true
+          authorizer:
+            name: ${self:service}-authorizer
+            type: COGNITO_USER_POOLS
+            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
   registrationDelete:
     handler: handler.del
     events:


### PR DESCRIPTION
## Changes
- Add Cognito authorization to /registrations GET endpoint for case where we get all registrations for an event

## Notes
- Message Victor for change justification
- This change breaks the Companion's use of the `/registrations` GET endpoint - follow-up PR on this repo will add API endpoints for Companion use
- This change breaks `bt-web-v2`'s Registration table because of permission errors - follow-up PR on bt-web-v2 will fix this

## Testing
Changes work on bt-web Admin registration table, not expected to break other Registrations microservice endpoints