### PR TITLE
Quests Implementation for Interactions Service

### DIFF
--- a/scripts/generateQuestsForEventRegistrations.js
+++ b/scripts/generateQuestsForEventRegistrations.js
@@ -15,6 +15,7 @@ const QUEST_SNACK = "QUEST_SNACK";
 const QUEST_BOOTH_STARTUP = "QUEST_STARTUP";
 const QUEST_BIGTECH = "QUEST_BIGTECH";
 const QUEST_PHOTOBOOTH = "QUEST_PHOTOBOOTH";
+const QUEST_WORKSHOP = "QUEST_WORKSHOP";
 const QUEST_CONNECT_FOUR = "QUEST_CONNECT_FOUR";
 const QUEST_CONNECT_TEN_H = "QUEST_CONNECT_TEN_H";
 const QUEST_BT_BOOTH_H = "QUEST_BT_BOOTH_H";
@@ -34,6 +35,7 @@ const QUESTS = [
   [QUEST_SNACK, 1, "Snack Seeker", "Grab some food."],
   [QUEST_BOOTH_STARTUP, 1, "Startup Explorer", "Visit a startup booth."],
   [QUEST_BIGTECH, 1, "Big League Scout", "Visit a big company booth."],
+  [QUEST_WORKSHOP, 1, "Workshop Wonder", "Attend Workshop 2."],
   [QUEST_PHOTOBOOTH, 1, "Memory Maker", "Take a photo to reminisce."]
 ];
 
@@ -90,6 +92,7 @@ const questsForEventRegistrations = async (eventID, year) => {
 
   let count = 0;
   let users = 0;
+  const promises = [];
   for (let i = 0; i < registrations.Items.length; i++) {
     try {
       const userQuests = userQuestsArray(
@@ -98,11 +101,12 @@ const questsForEventRegistrations = async (eventID, year) => {
       );
 
       users++;
-
       for (let j = 0; j < userQuests.length; j++) {
-        await create(userQuests[j], QUESTS_TABLE);
-        count++;
+        promises.push(create(userQuests[j], QUESTS_TABLE));
       }
+
+      await Promise.all(promises);
+      count += userQuests.length;
 
       console.log(`Quests created for user: ${registrations.Items[i].id}`);
     } catch (err) {

--- a/services/interactions/constants.js
+++ b/services/interactions/constants.js
@@ -6,10 +6,17 @@ export const PARTNER = "NFC_PARTNER";
 
 export const QUEST_CONNECT_ONE = "QUEST_CONNECT_ONE";
 export const QUEST_SNACK = "QUEST_SNACK";
-export const QUEST_BOOTH_STARTUP = "QUEST_STARTUP";
+export const QUEST_STARTUP = "QUEST_STARTUP";
 export const QUEST_BIGTECH = "QUEST_BIGTECH";
+export const QUEST_WORKSHOP = "QUEST_WORKSHOP";
 export const QUEST_PHOTOBOOTH = "QUEST_PHOTOBOOTH";
 export const QUEST_CONNECT_FOUR = "QUEST_CONNECT_FOUR";
 export const QUEST_BT_BOOTH_H = "QUEST_BT_BOOTH_H";
 export const QUEST_CONNECT_TEN_H = "QUEST_CONNECT_TEN_H";
 export const QUEST_CONNECT_EXEC_H = "QUEST_CONNECT_EXEC_H";
+
+export const WORKSHOP_TWO = "WORKSHOP_TWO";
+
+export const BIGTECH = ["Meta", "Google"]; // incomplete, check with partnerships
+export const STARTUPS = ["Perplexity", "InternInside", "Xpress"];
+export const PHOTOBOOTH = "PHOTO";

--- a/services/interactions/handler.js
+++ b/services/interactions/handler.js
@@ -131,7 +131,7 @@ export const getAllQuests = async (event, ctx, callback) => {
     const result = await docClient.send(command);
 
     const response = handlerHelpers.createResponse(200, {
-      message: `all connections for ${profileData.registrationID}`,
+      message: `all quests for ${profileData.registrationID}`,
       data: result.Items
     });
 

--- a/services/interactions/handler.js
+++ b/services/interactions/handler.js
@@ -1,19 +1,15 @@
 import {
-  CONNECTIONS_TABLE, QRS_TABLE
+  CONNECTIONS_TABLE,
+  QRS_TABLE,
+  QUESTS_TABLE
 } from "../../constants/tables";
 import db from "../../lib/db";
 import docClient from "../../lib/docClient";
 import handlerHelpers from "../../lib/handlerHelpers";
 import helpers from "../../lib/handlerHelpers";
-import {
-  CURRENT_EVENT
-} from "./constants";
-import {
-  handleBooth, handleConnection, handleWorkshop
-} from "./helpers";
-import {
-  QueryCommand
-} from "@aws-sdk/lib-dynamodb";
+import { CURRENT_EVENT } from "./constants";
+import { handleBooth, handleConnection, handleWorkshop } from "./helpers";
+import { QueryCommand } from "@aws-sdk/lib-dynamodb";
 
 const CONNECTION = "CONNECTION";
 const WORK = "WORKSHOP";
@@ -23,42 +19,45 @@ export const postInteraction = async (event, ctx, callback) => {
   try {
     const data = JSON.parse(event.body);
 
-    helpers.checkPayloadProps(data, {
-      userID: {
-        required: true
-      },
-      interactionType: {
-        required: true
-      },
-      eventParam: {
-        required: true
-      }
-    });
+    try {
+      helpers.checkPayloadProps(data, {
+        userID: {
+          required: true
+        },
+        eventType: {
+          required: true
+        },
+        eventParam: {
+          required: true
+        }
+      });
+    } catch (error) {
+      callback(null, error);
+      return null;
+    }
 
     const timestamp = new Date().getTime();
-    const {
-      userID, interactionType, eventParam
-    } = data;
+    const { userID, eventType, eventParam } = data;
 
     let response;
 
-    switch (interactionType) {
-    case CONNECTION:
-      response = await handleConnection(userID, eventParam, timestamp);
-      break;
+    switch (eventType) {
+      case CONNECTION:
+        response = await handleConnection(userID, eventParam, timestamp);
+        break;
 
-    case WORK:
-      response = await handleWorkshop(userID, eventParam, timestamp);
-      break;
+      case WORK:
+        response = await handleWorkshop(userID, eventParam, timestamp);
+        break;
 
-    case BOOTH:
-      response = await handleBooth(userID, eventParam, timestamp);
-      break;
+      case BOOTH:
+        response = await handleBooth(userID, eventParam, timestamp);
+        break;
 
-    default:
-      throw handlerHelpers.createResponse(400, {
-        message: "interactionType argument does not match known case"
-      });
+      default:
+        throw handlerHelpers.createResponse(400, {
+          message: "interactionType argument does not match known case"
+        });
     }
 
     callback(null, response);
@@ -79,9 +78,7 @@ export const getAllConnections = async (event, ctx, callback) => {
 
     const userID = event.pathParameters.id;
 
-    const {
-      data: profileData
-    } = await db.getOne(userID, QRS_TABLE, {
+    const { data: profileData } = await db.getOne(userID, QRS_TABLE, {
       "eventID;year": CURRENT_EVENT
     });
 
@@ -113,4 +110,38 @@ export const getAllConnections = async (event, ctx, callback) => {
   return null;
 };
 
-export const getAllQuests = (event, ctx, callback) => {};
+export const getAllQuests = async (event, ctx, callback) => {
+  try {
+    if (!event.pathParameters || !event.pathParameters.id)
+      throw helpers.missingIdQueryResponse("id");
+
+    const userID = event.pathParameters.id;
+
+    const { data: profileData } = await db.getOne(userID, QRS_TABLE, {
+      "eventID;year": CURRENT_EVENT
+    });
+
+    const command = new QueryCommand({
+      ExpressionAttributeValues: {
+        ":uid": profileData.registrationID
+      },
+      KeyConditionExpression: "userID = :uid",
+      TableName: QUESTS_TABLE + (process.env.ENVIRONMENT || "")
+    });
+    const result = await docClient.send(command);
+
+    const response = handlerHelpers.createResponse(200, {
+      message: `all connections for ${profileData.registrationID}`,
+      data: result.Items
+    });
+
+    callback(null, response);
+  } catch (err) {
+    console.error(err);
+    throw handlerHelpers.createResponse(500, {
+      message: "Internal server error"
+    });
+  }
+
+  return null;
+};

--- a/services/interactions/helpers.js
+++ b/services/interactions/helpers.js
@@ -1,17 +1,38 @@
+import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import {
-  QueryCommand
-} from "@aws-sdk/lib-dynamodb";
-import {
-  QRS_TABLE, CONNECTIONS_TABLE
+  QRS_TABLE,
+  CONNECTIONS_TABLE,
+  QUESTS_TABLE
 } from "../../constants/tables";
 import db from "../../lib/db";
 import handlerHelpers from "../../lib/handlerHelpers";
 import docClient from "../../lib/docClient";
 import {
-  ATTENDEE, CURRENT_EVENT, EXEC, PARTNER
+  ATTENDEE,
+  BIGTECH,
+  CURRENT_EVENT,
+  EXEC,
+  PARTNER,
+  QUEST_BIGTECH,
+  QUEST_STARTUP,
+  QUEST_CONNECT_FOUR,
+  QUEST_CONNECT_ONE,
+  QUEST_CONNECT_TEN_H,
+  QUEST_WORKSHOP,
+  STARTUPS,
+  WORKSHOP_TWO,
+  PHOTOBOOTH,
+  QUEST_PHOTOBOOTH,
+  QUEST_CONNECT_EXEC_H
 } from "./constants";
 
 export const handleConnection = async (userID, connID, timestamp) => {
+  if (userID == connID) {
+    return handlerHelpers.createResponse(400, {
+      message: "Cannot connect with yourself"
+    });
+  }
+
   let profileData = await db.getOne(userID, QRS_TABLE, {
     "eventID;year": CURRENT_EVENT
   });
@@ -27,12 +48,8 @@ export const handleConnection = async (userID, connID, timestamp) => {
     });
   }
 
-  const {
-    data: userData
-  } = profileData;
-  const {
-    data: connData, type
-  } = connProfileData;
+  let { data: userData, type: userType } = profileData;
+  let { data: connData, type: connType } = connProfileData;
 
   if (
     await isDuplicateRequest(userData.registrationID, connData.registrationID)
@@ -42,134 +59,176 @@ export const handleConnection = async (userID, connID, timestamp) => {
     });
   }
 
+  let swap = false;
+  if (userType == EXEC && connType == EXEC) {
+    connType = EXEC + EXEC;
+  } else if (userType == EXEC) {
+    // in the case that the first user is an EXEC, switch required for switch-case logic to catch
+    userData = [connData, (connData = userData)][0];
+    userType = [connType, (connType = userType)][0];
+    userID = [connID, (connID = userID)][0];
+    swap = true;
+  }
+
   const userPut = {
     userID: userData.registrationID,
-    connID: connData.registrationID,
     obfuscatedID: connID,
     "eventID;year": CURRENT_EVENT,
     createdAt: timestamp,
     ...(connData.linkedinURL
       ? {
-        linkedinURL: connData.linkedinURL
-      }
-      : {
-      }),
+          linkedinURL: connData.linkedinURL
+        }
+      : {}),
     ...(connData.fname
       ? {
-        fname: connData.fname
-      }
-      : {
-      }),
+          fname: connData.fname
+        }
+      : {}),
     ...(connData.lname
       ? {
-        lname: connData.lname
-      }
-      : {
-      }),
+          lname: connData.lname
+        }
+      : {}),
     ...(connData.major
       ? {
-        major: connData.major
-      }
-      : {
-      }),
+          major: connData.major
+        }
+      : {}),
     ...(connData.year
       ? {
-        year: connData.year
-      }
-      : {
-      }),
+          year: connData.year
+        }
+      : {}),
     ...(connData.company
       ? {
-        company: connData.company
-      }
-      : {
-      }),
+          company: connData.company
+        }
+      : {}),
     ...(connData.title
       ? {
-        title: connData.title
-      }
-      : {
-      })
+          title: connData.title
+        }
+      : {})
   };
 
   const connPut = {
     userID: connData.registrationID,
-    connID: userData.registrationID,
     obfuscatedID: userID,
     "eventID;year": CURRENT_EVENT,
     createdAt: timestamp,
     ...(userData.linkedinURL
       ? {
-        linkedinURL: userData.linkedinURL
-      }
-      : {
-      }),
+          linkedinURL: userData.linkedinURL
+        }
+      : {}),
     ...(userData.fname
       ? {
-        fname: userData.fname
-      }
-      : {
-      }),
+          fname: userData.fname
+        }
+      : {}),
     ...(userData.lname
       ? {
-        lname: userData.lname
-      }
-      : {
-      }),
+          lname: userData.lname
+        }
+      : {}),
     ...(userData.major
       ? {
-        major: userData.major
-      }
-      : {
-      }),
+          major: userData.major
+        }
+      : {}),
     ...(userData.year
       ? {
-        year: userData.year
-      }
-      : {
-      }),
+          year: userData.year
+        }
+      : {}),
     ...(userData.company
       ? {
-        company: userData.company
-      }
-      : {
-      }),
+          company: userData.company
+        }
+      : {}),
     ...(userData.title
       ? {
-        title: userData.title
-      }
-      : {
-      })
+          title: userData.title
+        }
+      : {})
   };
 
-  switch (type) {
-  case ATTENDEE:
-    try {
-      // potential race condition -> use transactions to fix, but will take time to implement
-      await db.put(connPut, CONNECTIONS_TABLE, true);
-      await db.put(userPut, CONNECTIONS_TABLE, true);
-      // logic to check if quests entry has been made for connection
-      // put command to update the quest entry
-    } catch (error) {
-      console.error(error);
-      return handlerHelpers.createResponse(500, {
-        message: "Internal server error"
-      });
-    }
-    break;
+  switch (connType) {
+    case EXEC + EXEC:
+      try {
+        await incrementQuestProgress(
+          connData.registrationID,
+          QUEST_CONNECT_EXEC_H
+        );
+      } catch (error) {
+        console.error(error);
+        return handlerHelpers.createResponse(500, {
+          message: "Internal server error"
+        });
+      }
 
-  case EXEC:
-    break;
+    case EXEC:
+      try {
+        await incrementQuestProgress(
+          userData.registrationID,
+          QUEST_CONNECT_EXEC_H
+        );
+      } catch (error) {
+        console.error(error);
+        return handlerHelpers.createResponse(500, {
+          message:
+            "Internal server error, data inconsistency :( not all quests progressed"
+        });
+      }
 
-  case PARTNER:
-    break;
+    // case ATTENDEE:
+    default:
+      try {
+        // potential race condition -> use transactions to fix, but will take time to implement
+        await db.put(connPut, CONNECTIONS_TABLE, true);
+        await db.put(userPut, CONNECTIONS_TABLE, true);
+        await incrementQuestProgress(
+          userData.registrationID,
+          QUEST_CONNECT_ONE
+        );
+        await incrementQuestProgress(
+          userData.registrationID,
+          QUEST_CONNECT_FOUR
+        );
+        await incrementQuestProgress(
+          userData.registrationID,
+          QUEST_CONNECT_TEN_H
+        );
+        await incrementQuestProgress(
+          connData.registrationID,
+          QUEST_CONNECT_ONE
+        );
+        await incrementQuestProgress(
+          connData.registrationID,
+          QUEST_CONNECT_FOUR
+        );
+        await incrementQuestProgress(
+          connData.registrationID,
+          QUEST_CONNECT_TEN_H
+        );
+      } catch (error) {
+        console.error(error);
+        return handlerHelpers.createResponse(500, {
+          message: "Internal server error"
+        });
+      }
+      break;
 
-  default:
-    break;
+    // case PARTNER:
+    //   break;
+
+    // default:
+    //   break;
   }
 
   return handlerHelpers.createResponse(200, {
-    message: `Connection created with ${connData.registrationID}`
+    message: `Connection created with ${swap ? userData.fname : connData.fname}`
   });
 };
 
@@ -181,22 +240,101 @@ const isDuplicateRequest = async (userID, connID) => {
         ":conn": connID,
         ":uid": userID
       },
-      KeyConditionExpression: "connID = :conn AND userID = :uid",
-      ProjectionExpression: "userID, connID",
+      KeyConditionExpression: "obfuscatedID = :conn AND userID = :uid",
+      ProjectionExpression: "userID, obfuscatedID",
       TableName: CONNECTIONS_TABLE + (process.env.ENVIRONMENT || "")
     });
 
     result = await docClient.send(command);
   } catch (error) {
     console.error(error);
-    throw handlerHelpers.createResponse(500, {
-      message: "dynamodb silly"
-    });
+    throw error;
   }
 
   return result.Items.length > 0;
 };
 
-export const handleWorkshop = async (userID, workshopID, timestamp) => {};
+export const handleWorkshop = async (profileID, workshopID, timestamp) => {
+  const { data } = await db.getOne(profileID, QRS_TABLE, {
+    "eventID;year": CURRENT_EVENT
+  });
 
-export const handleBooth = async (userID, boothID, timestamp) => {};
+  let userID = data.registrationID;
+
+  if (workshopID != WORKSHOP_TWO) {
+    return handlerHelpers.createResponse(200, {
+      message: `Checked into ${workshopID}`
+    });
+  }
+
+  try {
+    await incrementQuestProgress(userID, QUEST_WORKSHOP);
+    return handlerHelpers.createResponse(200, {
+      message: "Checked into workshop 2"
+    });
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export const handleBooth = async (profileID, boothID, timestamp) => {
+  const { data } = await db.getOne(profileID, QRS_TABLE, {
+    "eventID;year": CURRENT_EVENT
+  });
+
+  let userID = data.registrationID;
+
+  if (BIGTECH.includes(boothID)) {
+    try {
+      await incrementQuestProgress(userID, QUEST_BIGTECH);
+      return handlerHelpers.createResponse(200, {
+        message: `Checked into booth ${boothID}`
+      });
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  }
+
+  if (STARTUPS.includes(boothID)) {
+    try {
+      await incrementQuestProgress(userID, QUEST_STARTUP);
+      return handlerHelpers.createResponse(200, {
+        message: `Checked into booth ${boothID}`
+      });
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  }
+
+  if (boothID == PHOTOBOOTH) {
+    try {
+      await incrementQuestProgress(userID, QUEST_PHOTOBOOTH);
+      return handlerHelpers.createResponse(200, {
+        message: `Checked into booth ${boothID}`
+      });
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  }
+};
+
+const incrementQuestProgress = async (userID, questID) => {
+  const command = new UpdateCommand({
+    TableName: QUESTS_TABLE + (process.env.ENVIRONMENT || ""),
+    Key: {
+      userID,
+      questID
+    },
+    UpdateExpression: "ADD progress :incrementValue",
+    ExpressionAttributeValues: {
+      ":incrementValue": 1
+    },
+    ReturnValues: "ALL_NEW"
+  });
+
+  return await docClient.send(command);
+};

--- a/services/interactions/helpers.js
+++ b/services/interactions/helpers.js
@@ -1,4 +1,6 @@
-import { QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  QueryCommand, UpdateCommand
+} from "@aws-sdk/lib-dynamodb";
 import {
   QRS_TABLE,
   CONNECTIONS_TABLE,
@@ -48,8 +50,12 @@ export const handleConnection = async (userID, connID, timestamp) => {
     });
   }
 
-  let { data: userData, type: userType } = profileData;
-  let { data: connData, type: connType } = connProfileData;
+  let {
+    data: userData, type: userType
+  } = profileData;
+  let {
+    data: connData, type: connType
+  } = connProfileData;
 
   if (
     await isDuplicateRequest(userData.registrationID, connData.registrationID)
@@ -77,39 +83,46 @@ export const handleConnection = async (userID, connID, timestamp) => {
     createdAt: timestamp,
     ...(connData.linkedinURL
       ? {
-          linkedinURL: connData.linkedinURL
-        }
-      : {}),
+        linkedinURL: connData.linkedinURL
+      }
+      : {
+      }),
     ...(connData.fname
       ? {
-          fname: connData.fname
-        }
-      : {}),
+        fname: connData.fname
+      }
+      : {
+      }),
     ...(connData.lname
       ? {
-          lname: connData.lname
-        }
-      : {}),
+        lname: connData.lname
+      }
+      : {
+      }),
     ...(connData.major
       ? {
-          major: connData.major
-        }
-      : {}),
+        major: connData.major
+      }
+      : {
+      }),
     ...(connData.year
       ? {
-          year: connData.year
-        }
-      : {}),
+        year: connData.year
+      }
+      : {
+      }),
     ...(connData.company
       ? {
-          company: connData.company
-        }
-      : {}),
+        company: connData.company
+      }
+      : {
+      }),
     ...(connData.title
       ? {
-          title: connData.title
-        }
-      : {})
+        title: connData.title
+      }
+      : {
+      })
   };
 
   const connPut = {
@@ -119,106 +132,113 @@ export const handleConnection = async (userID, connID, timestamp) => {
     createdAt: timestamp,
     ...(userData.linkedinURL
       ? {
-          linkedinURL: userData.linkedinURL
-        }
-      : {}),
+        linkedinURL: userData.linkedinURL
+      }
+      : {
+      }),
     ...(userData.fname
       ? {
-          fname: userData.fname
-        }
-      : {}),
+        fname: userData.fname
+      }
+      : {
+      }),
     ...(userData.lname
       ? {
-          lname: userData.lname
-        }
-      : {}),
+        lname: userData.lname
+      }
+      : {
+      }),
     ...(userData.major
       ? {
-          major: userData.major
-        }
-      : {}),
+        major: userData.major
+      }
+      : {
+      }),
     ...(userData.year
       ? {
-          year: userData.year
-        }
-      : {}),
+        year: userData.year
+      }
+      : {
+      }),
     ...(userData.company
       ? {
-          company: userData.company
-        }
-      : {}),
+        company: userData.company
+      }
+      : {
+      }),
     ...(userData.title
       ? {
-          title: userData.title
-        }
-      : {})
+        title: userData.title
+      }
+      : {
+      })
   };
 
   switch (connType) {
-    case EXEC + EXEC:
-      try {
-        await incrementQuestProgress(
-          connData.registrationID,
-          QUEST_CONNECT_EXEC_H
-        );
-      } catch (error) {
-        console.error(error);
-        return handlerHelpers.createResponse(500, {
-          message: "Internal server error"
-        });
-      }
+  case EXEC + EXEC:
+    try {
+      await incrementQuestProgress(
+        connData.registrationID,
+        QUEST_CONNECT_EXEC_H
+      );
+    } catch (error) {
+      console.error(error);
+      return handlerHelpers.createResponse(500, {
+        message: "Internal server error"
+      });
+    }
 
-    case EXEC:
-      try {
-        await incrementQuestProgress(
-          userData.registrationID,
-          QUEST_CONNECT_EXEC_H
-        );
-      } catch (error) {
-        console.error(error);
-        return handlerHelpers.createResponse(500, {
-          message:
+  case EXEC:
+    try {
+      await incrementQuestProgress(
+        userData.registrationID,
+        QUEST_CONNECT_EXEC_H
+      );
+    } catch (error) {
+      console.error(error);
+      return handlerHelpers.createResponse(500, {
+        message:
             "Internal server error, data inconsistency :( not all quests progressed"
-        });
-      }
+      });
+    }
 
     // case ATTENDEE:
-    default:
-      try {
-        // potential race condition -> use transactions to fix, but will take time to implement
-        await db.put(connPut, CONNECTIONS_TABLE, true);
-        await db.put(userPut, CONNECTIONS_TABLE, true);
-        await incrementQuestProgress(
-          userData.registrationID,
-          QUEST_CONNECT_ONE
-        );
-        await incrementQuestProgress(
-          userData.registrationID,
-          QUEST_CONNECT_FOUR
-        );
-        await incrementQuestProgress(
-          userData.registrationID,
-          QUEST_CONNECT_TEN_H
-        );
-        await incrementQuestProgress(
-          connData.registrationID,
-          QUEST_CONNECT_ONE
-        );
-        await incrementQuestProgress(
-          connData.registrationID,
-          QUEST_CONNECT_FOUR
-        );
-        await incrementQuestProgress(
-          connData.registrationID,
-          QUEST_CONNECT_TEN_H
-        );
-      } catch (error) {
-        console.error(error);
-        return handlerHelpers.createResponse(500, {
-          message: "Internal server error"
-        });
-      }
-      break;
+  default:
+    try {
+      // potential race condition -> use transactions to fix, but will take time to implement
+      await db.put(connPut, CONNECTIONS_TABLE, true);
+      await db.put(userPut, CONNECTIONS_TABLE, true);
+      await incrementQuestProgress(
+        userData.registrationID,
+        QUEST_CONNECT_ONE
+      );
+      await incrementQuestProgress(
+        userData.registrationID,
+        QUEST_CONNECT_FOUR
+      );
+      await incrementQuestProgress(
+        userData.registrationID,
+        QUEST_CONNECT_TEN_H
+      );
+      await incrementQuestProgress(
+        connData.registrationID,
+        QUEST_CONNECT_ONE
+      );
+      await incrementQuestProgress(
+        connData.registrationID,
+        QUEST_CONNECT_FOUR
+      );
+      await incrementQuestProgress(
+        connData.registrationID,
+        QUEST_CONNECT_TEN_H
+      );
+    } catch (error) {
+      console.error(error);
+      return handlerHelpers.createResponse(500, {
+        message: "Internal server error"
+      });
+    }
+    break;
 
     // case PARTNER:
     //   break;
@@ -255,7 +275,9 @@ const isDuplicateRequest = async (userID, connID) => {
 };
 
 export const handleWorkshop = async (profileID, workshopID, timestamp) => {
-  const { data } = await db.getOne(profileID, QRS_TABLE, {
+  const {
+    data
+  } = await db.getOne(profileID, QRS_TABLE, {
     "eventID;year": CURRENT_EVENT
   });
 
@@ -279,7 +301,9 @@ export const handleWorkshop = async (profileID, workshopID, timestamp) => {
 };
 
 export const handleBooth = async (profileID, boothID, timestamp) => {
-  const { data } = await db.getOne(profileID, QRS_TABLE, {
+  const {
+    data
+  } = await db.getOne(profileID, QRS_TABLE, {
     "eventID;year": CURRENT_EVENT
   });
 

--- a/services/interactions/serverless.yml
+++ b/services/interactions/serverless.yml
@@ -58,25 +58,25 @@ functions:
           path: interactions/
           method: post
           cors: true
-  interactionGetAll:
+  interactionJournalGetAll:
     handler: handler.getAllConnections
     events:
       - http:
-          path: interactions/{id}
+          path: interactions/journal/{id}
           method: get
           request:
             parameters:
               path:
                 id: true
           cors: true
-  questsGetAll:
+  interactionQuestsGetAll:
     handler: handler.getAllQuests
     events:
       - http:
-        path: quests/{id}
-        method: get
-        request:
-          parameters:
-            path:
-              id: true
-        cors: true
+          path: interactions/quests/{id}
+          method: get
+          request:
+            parameters:
+              path:
+                id: true
+          cors: true


### PR DESCRIPTION
## Changes
- endpoint path changes: connections now on interactions/journal/{userID} and quests are on interactions/quests/{userID}
- added quests logic, handling boothing, workshops, and different connection metrics
- logic separated by event type, all leverage incrementQuestProgress helper
- added mandatory workshop 2 quest to script generation

## Notes
- some hacky logic to simplify case handling of exec/user quests through switch-case and swapping (see comments for explanation)

## Testing
- created mock data for obfuscatedIDs: ShortTaxesDie, TestDudeOne, TestDudeTwo
- smoke tested different cases for users and booths

Supported Endpoints:
POST: /interactions
(some example request bodies for reference... documentation will be posted on notion soon)
<img width="374" alt="image" src="https://github.com/user-attachments/assets/7766609d-50d1-4ee6-9660-547d3e471b8f" />
<img width="325" alt="image" src="https://github.com/user-attachments/assets/d845274e-39fd-4da5-a51b-ab23cdc037c6" />

Notes about response codes
- 200 guarantees success, with message descriptive of action but useful only for debugging
- 400 means an invalid request was made, not necessarily an error
- 500 may not provide prescriptive logs, check cloudwatch (from my own testing I haven't run into issues but unsure what happens under load)


GET: /interactions/journal/{userID}
Example response: journal
<img width="525" alt="image" src="https://github.com/user-attachments/assets/6227ccda-a7b1-4c67-868a-3be622c5f24c" />

GET: /interactions/quests/{userID}
Example response: quests 
<img width="576" alt="image" src="https://github.com/user-attachments/assets/fb240690-2b59-4c15-83af-fee6f4476c98" />
