### PR TITLE
pin serverless version to 3.39 in GH actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
      run: |
         cd services
         for DIR in *; do
-          (cd $DIR && sls deploy --conceal \
+          (cd $DIR && npx sls deploy --conceal \
             --stage dev \
             && cd ..) & done; wait
 


### PR DESCRIPTION
Fixing GH CI issue, version mismatch between node and serverless, running on CI appears to use global version 3.40 causing the deployment to fail. Will try to use npx to pin version to 3.39 by using version indicated with package.json.

