### PR TITLE
pin node version to 20.7 in GH actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
      run: |
         cd services
         for DIR in *; do
-          (cd $DIR && npx sls deploy --conceal \
+          (cd $DIR && sls deploy --conceal \
             --stage dev \
             && cd ..) & done; wait
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
    - name: Use Node.js ${{ matrix.node-version }}
      uses: actions/setup-node@v4
      with:
-       node-version: '20.x'
+       node-version: '20.7'
 
    # https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows
    - name: Cache node modules

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,17 @@ jobs:
       NODE_ENV: ${{ secrets.NODE_ENV }}
      run: |
         cd services
+        pids=()
+
         for DIR in *; do
           (cd $DIR && sls deploy --conceal \
             --stage dev \
-            && cd ..) & done; wait
+            && cd ..) & pids +=($!) & done; 
+
+        for pid in "${pids[@]}"; do
+          wait $pid || exit 1
+
+        wait
 
    - name: 'Deploy Prod'
      if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Node v 20.7 appears to be stable for serverless deployments, others create type errors.

Maybe something worth looking into is to migrate to a newer version of serverless, although it appears it's still incompatible with node 20.19. Newer versions of Node 22.xx appear to have support but due to the CLI of serverless updating this makes it unstable and may cause deployments to randomly fail in the future.