### PR TITLE
Fix GH Action Deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,16 @@ jobs:
       NODE_ENV: ${{ secrets.NODE_ENV }}
      run: |
         cd services
+        pids=()
+
         for DIR in *; do
-          (cd $DIR && sls deploy --stage prod --conceal \
-            && cd ..) & done; wait
+          cd "$DIR"
+          sls deploy --conceal --stage prod &
+          pid=$!
+          pids+=("$pid")
+          cd ..
+        done
+
+        for pid in "${pids[@]}"; do
+          wait "$pid" || exit 1
+        done


### PR DESCRIPTION
## Changes
- update GH workflow for deployments to use Node v 20.7
- update deployment script to perform reduce on PID status of serverless deployments, better informing for deployment failures

## Notes
Node v 20.7 appears to be stable for serverless deployments, others create type errors.
Maybe something worth looking into is to migrate to a newer version of serverless, although it appears it's still incompatible with node 20.19. Newer versions of Node 22.xx appear to have support but due to the CLI of serverless updating this makes it unstable and may cause deployments to randomly fail in the future.

> !! We may also want a discussion on whether this is the approach we want to follow, although serverless should ignore unchanged handlers in my testing it redeployed all dev apis, and this also probably means we need to fix some bugs in legacy microservices

## Testing
I've tested by making some changes to the deployment and merging into dev already, it's working as intended (apart from some handlers in the members-api having malformed path variables in the .yaml) 

<img width="904" alt="image" src="https://github.com/user-attachments/assets/ab06664a-0f35-4745-a7f8-068989fd7a91" />
^(image of a GH action running; dev deployments are now working as intended)

