### PR TITLE
Fixed discord interactions endpoint verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "concurrently": "^6.2.0",
     "copy-dynamodb-table": "^2.2.1",
     "csv-parser": "^3.0.0",
+    "discord-interactions": "^4.3.0",
     "dotenv": "^16.0.3",
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.2",
@@ -22,6 +23,7 @@
     "path": "^0.12.7",
     "serverless": "^3.39.0",
     "serverless-dynamodb": "^0.2.54",
+    "tweetnacl": "^1.0.3",
     "yaml": "^1.10.2"
   },
   "scripts": {

--- a/services/bots/handlerDiscord.js
+++ b/services/bots/handlerDiscord.js
@@ -9,8 +9,7 @@ const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 export const interactions = (event, ctx, callback) => {
   const body = JSON.parse(event.body);
 
-  const isValid = verifyRequestSignature(event);
-  if (!isValid) {
+  if (!verifyRequestSignature(event)) {
     console.error("Invalid request signature");
     return callback(null, {
       statusCode: 401,
@@ -35,11 +34,9 @@ export const interactions = (event, ctx, callback) => {
 
   if (type === InteractionType.PING) {
     console.log("Received PING interaction");
-    return callback(null, {         
+    return callback(null, {
       statusCode: 200,
-      body: JSON.stringify({ 
-        type: InteractionResponseType.PONG 
-      }) 
+      body: JSON.stringify({ type: InteractionResponseType.PONG })
     });
   }
 

--- a/services/bots/handlerDiscord.js
+++ b/services/bots/handlerDiscord.js
@@ -1,6 +1,6 @@
 import { InteractionResponseType, InteractionType } from "discord-interactions";
-import handlerHelpers from "../../lib/handlerHelpers";
-import { DiscordRequest } from "./helpersDiscord";
+import handlerHelpers from "../../lib/handlerHelpers.js";
+import { DiscordRequest, verifyRequestSignature } from "./helpersDiscord.js";
 
 const DISCORD_APPLICATION_ID = process.env.DISCORD_APPLICATION_ID;
 const DISCORD_PUBLIC_KEY = process.env.DISCORD_PUBLIC_KEY;
@@ -8,23 +8,39 @@ const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 
 export const interactions = (event, ctx, callback) => {
   const body = JSON.parse(event.body);
+
+  const isValid = verifyRequestSignature(event);
+  if (!isValid) {
+    console.error("Invalid request signature");
+    return callback(null, {
+      statusCode: 401,
+      body: JSON.stringify({ error: "Invalid request signature" })
+    });
+  }
+
   handlerHelpers.checkPayloadProps(body, {
     id: {
-      required: true
+      required: false
     },
     type: {
       required: true,
-      type: "string"
+      type: "number"
     },
     data: {
-      required: true
+      required: false
     }
   });
 
   const { id, type, data } = body;
 
   if (type === InteractionType.PING) {
-    return res.send({ type: InteractionResponseType.PONG });
+    console.log("Received PING interaction");
+    return callback(null, {         
+      statusCode: 200,
+      body: JSON.stringify({ 
+        type: InteractionResponseType.PONG 
+      }) 
+    });
   }
 
   //stub

--- a/services/bots/helpersDiscord.js
+++ b/services/bots/helpersDiscord.js
@@ -1,3 +1,4 @@
+import { verifyKey } from "discord-interactions";
 import fetch from "node-fetch";
 
 export async function DiscordRequest(endpoint, options) {
@@ -20,4 +21,29 @@ export async function DiscordRequest(endpoint, options) {
   }
 
   return res;
+}
+
+export function verifyRequestSignature(req) {
+  console.log(JSON.stringify(req));
+  const signature = req.headers["X-Signature-Ed25519"];
+  const timestamp = req.headers["X-Signature-Timestamp"];
+  const body = req.body;
+
+  if (!signature || !timestamp) {
+    console.error("Missing signature or timestamp in request headers");
+    return false
+  }
+  console.log("body", body);
+  console.log("public key", process.env.DISCORD_PUBLIC_KEY);
+  console.log("signature", signature);
+  console.log("timestamp", timestamp);
+
+  const isValid = verifyKey(
+    body,
+    signature,
+    timestamp,
+    process.env.DISCORD_PUBLIC_KEY
+  );
+
+  return isValid;
 }

--- a/services/bots/helpersDiscord.js
+++ b/services/bots/helpersDiscord.js
@@ -24,7 +24,7 @@ export async function DiscordRequest(endpoint, options) {
 }
 
 export function verifyRequestSignature(req) {
-  console.log(JSON.stringify(req));
+  let isValid = false;
   const signature = req.headers["X-Signature-Ed25519"];
   const timestamp = req.headers["X-Signature-Timestamp"];
   const body = req.body;
@@ -34,11 +34,16 @@ export function verifyRequestSignature(req) {
     return false
   }
 
-  const isValid = nacl.sign.detached.verify(
-    Buffer.from(timestamp + body),
-    Buffer.from(signature, "hex"),
-    Buffer.from(process.env.DISCORD_PUBLIC_KEY, "hex")
-  );
+  try {
+    isValid = nacl.sign.detached.verify(
+      Buffer.from(timestamp + body),
+      Buffer.from(signature, "hex"),
+      Buffer.from(process.env.DISCORD_PUBLIC_KEY, "hex")
+    );
+  } catch (error) {
+    console.error("Error verifying signature:", error);
+    return false;
+  }
 
   return isValid;
 }

--- a/services/bots/helpersDiscord.js
+++ b/services/bots/helpersDiscord.js
@@ -1,4 +1,4 @@
-import { verifyKey } from "discord-interactions";
+import nacl from "tweetnacl";
 import fetch from "node-fetch";
 
 export async function DiscordRequest(endpoint, options) {
@@ -33,16 +33,11 @@ export function verifyRequestSignature(req) {
     console.error("Missing signature or timestamp in request headers");
     return false
   }
-  console.log("body", body);
-  console.log("public key", process.env.DISCORD_PUBLIC_KEY);
-  console.log("signature", signature);
-  console.log("timestamp", timestamp);
 
-  const isValid = verifyKey(
-    body,
-    signature,
-    timestamp,
-    process.env.DISCORD_PUBLIC_KEY
+  const isValid = nacl.sign.detached.verify(
+    Buffer.from(timestamp + body),
+    Buffer.from(signature, "hex"),
+    Buffer.from(process.env.DISCORD_PUBLIC_KEY, "hex")
   );
 
   return isValid;

--- a/services/bots/serverless.yml
+++ b/services/bots/serverless.yml
@@ -37,17 +37,17 @@ functions:
     handler: handlerDiscord.interactions
     events:
       - http:
-        path: discord/interactions
-        method: post
-        cors: true
+          path: discord/interactions
+          method: post
+          cors: true
 
   discordWebhook:
     handler: handlerDiscord.webhook
     events:
       - http:
-        path: discord/webhook
-        method: post
-        cors: true
+          path: discord/webhook
+          method: post
+          cors: true
 
   slackGithubReminder:
     handler: handlerSlack.slackGithubReminder


### PR DESCRIPTION
👷 **Changes:**
A brief summary of what changes were introduced.
- Replaced discord-interactions verification with manual signature validation using tweetnacl
💭 **Notes:**
Any additional things to take into consideration.
- to test your commands from your local server, you need to set up a tunnel (i prefer ngrok) to proxy requests from discord to your localhost port. it should look something like this: `https://acca-24-85-248-82.ngrok-free.app/dev/discord/interactions` which points to localhost:4016 or something
**Wait! Before you merge, have you checked the following:**
- [ ] Serverless tests are passing (Check travis build logs, CI is currently broken)
- [ ] PR is has approving review(s)
