### PR TITLE
Connections Rewrite 

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -9,7 +9,8 @@ import {
   QueryCommand,
   BatchGetCommand,
   DeleteCommand,
-  UpdateCommand
+  UpdateCommand,
+  TransactWriteCommand
 } from "@aws-sdk/lib-dynamodb";
 
 export default {
@@ -259,24 +260,72 @@ export default {
     }
   },
 
-  query: async function (table, indexName, keyCondition, filters = {
-  }) {
+  putMultiple: async function (items, tables, createNew = false) {
+    try {
+      if (items.length != tables.length)
+        throw {
+          statusCode: err.statusCode || 502,
+          headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Credentials": true
+          },
+          type: "Transaction items does not match length of tables to write",
+          body: { items, tables }
+        };
+
+      if (items.length > 25 || items.length == 0)
+        throw {
+          statusCode: err.statusCode || 502,
+          headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Credentials": true
+          },
+          type: "Cannot exceed greater than 25 transaction items, or have an empty transaction",
+          body: { items, tables }
+        };
+
+      let conditionExpression = createNew
+        ? "attribute_not_exists(id)"
+        : "attribute_exists(id)";
+
+      const transactItems = items.map((obj, i) => {
+        return {
+          Put: {
+            Item: obj,
+            TableName: tables[i] + (process.env.ENVIRONMENT || ""),
+            ConditionExpression: conditionExpression
+          }
+        };
+      });
+
+      const params = {
+        TransactItems: transactItems
+      };
+
+      const command = new TransactWriteCommand(params);
+      const res = await docClient.send(command);
+      return res;
+    } catch (err) {
+      const errorResponse = this.dynamoErrorResponse(err);
+      throw errorResponse;
+    }
+  },
+
+  query: async function (table, indexName, keyCondition, filters = {}) {
     try {
       const params = {
         TableName: table + (process.env.ENVIRONMENT || ""),
         KeyConditionExpression: keyCondition.expression,
         ExpressionAttributeValues: {
           ...keyCondition.expressionValues,
-          ...(filters.ExpressionAttributeValues || {
-          })
+          ...(filters.ExpressionAttributeValues || {})
         }
       };
 
       if (keyCondition.expressionNames || filters.ExpressionAttributeNames) {
         params.ExpressionAttributeNames = {
           ...keyCondition.expressionNames,
-          ...(filters.ExpressionAttributeNames || {
-          })
+          ...(filters.ExpressionAttributeNames || {})
         };
       }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -120,9 +120,18 @@ export default {
       throw errorResponse;
     }
   },
+  getOneCustom: async function (params) {
+    try {
+      const command = new GetCommand(params);
+      const result = await docClient.send(command);
+      return result.Item || null;
+    } catch (err) {
+      const errorResponse = this.dynamoErrorResponse(err);
+      throw errorResponse;
+    }
+  },
 
-  scan: async function (table, filters = {
-  }, indexName = null) {
+  scan: async function (table, filters = {}, indexName = null) {
     try {
       const params = {
         TableName: table + (process.env.ENVIRONMENT || ""),

--- a/services/interactions/constants.js
+++ b/services/interactions/constants.js
@@ -1,9 +1,8 @@
 export const CURRENT_EVENT = "blueprint;2025";
 
-export const ATTENDEE = "NFC_ATTENDEE";
-export const EXEC = "NFC_EXEC"; // subject to change
 export const PARTNER = "Partner";
 
+export const QUEST_TOTAL_CONNECTIONS = "QUEST_TOTAL_CONNECTIONS";
 export const QUEST_CONNECT_ONE = "QUEST_CONNECT_ONE";
 export const QUEST_SNACK = "QUEST_SNACK";
 export const QUEST_STARTUP = "QUEST_STARTUP";

--- a/services/interactions/handler.js
+++ b/services/interactions/handler.js
@@ -20,7 +20,7 @@ const BOOTH = "BOOTH";
 
 export const postInteraction = async (event, ctx, callback) => {
   try {
-    const userID = event.requestContext.authorizer.claims.email;
+    const userID = event.requestContext.authorizer.claims.email.toLowerCase();
     const data = JSON.parse(event.body);
 
     try {
@@ -79,14 +79,6 @@ export const getAllConnections = async (event, ctx, callback) => {
 
     const { profileID } = memberData;
 
-    const params = {
-      TableName: PROFILES_TABLE + (process.env.ENVIRONMENT || ""),
-      Key: {
-        compositeID: `PROFILE#${profileID}`,
-        type: TYPES.CONNECTION
-      }
-    };
-
     const result = await db.query(PROFILES_TABLE, null, {
       expression:
         "compositeID = :compositeID AND  begins_with(#type, :typePrefix)",
@@ -121,7 +113,7 @@ export const getAllConnections = async (event, ctx, callback) => {
 
 export const getAllQuests = async (event, ctx, callback) => {
   try {
-    const userID = event.requestContext.authorizer.claims.email;
+    const userID = event.requestContext.authorizer.claims.email.toLowerCase();
 
     const command = new QueryCommand({
       ExpressionAttributeValues: {

--- a/services/interactions/helpers.js
+++ b/services/interactions/helpers.js
@@ -68,8 +68,8 @@ export const handleConnection = async (userID, connProfileID, timestamp) => {
     );
   }
 
-  const userProfile = q1[0];
-  const connProfile = q2[0];
+  let userProfile = q1;
+  let connProfile = q2;
 
   if (await isDuplicateRequest(userProfileID, connProfileID)) {
     return handlerHelpers.createResponse(200, {
@@ -89,9 +89,11 @@ export const handleConnection = async (userID, connProfileID, timestamp) => {
   const userPut = {
     compositeID: `${TYPES.PROFILE}#${userProfileID}`,
     type: `${TYPES.CONNECTION}#${connProfileID}`,
+    connectionID: connProfileID,
     createdAt: timestamp,
-    firstName: connProfile.fname,
-    lastName: connProfile.lname,
+    fname: connProfile.fname,
+    lname: connProfile.lname,
+    pronouns: connProfile.pronouns,
     ...(connProfile.major
       ? {
           major: connProfile.major
@@ -118,8 +120,9 @@ export const handleConnection = async (userID, connProfileID, timestamp) => {
     compositeID: `${TYPES.PROFILE}#${connProfileID}`,
     type: `${TYPES.CONNECTION}#${userProfileID}`,
     createdAt: timestamp,
-    firstName: userProfile.fname,
-    lastName: userProfile.lname,
+    fname: userProfile.fname,
+    lname: userProfile.lname,
+    pronouns: userProfile.pronouns,
     ...(userProfile.major
       ? {
           major: userProfile.major
@@ -159,9 +162,9 @@ export const handleConnection = async (userID, connProfileID, timestamp) => {
     default:
       promises.push(
         db.put(connPut, PROFILES_TABLE, true),
-        db.put(userPut, PROFILES_TABLE, true),
-        incrementQuestProgress(userProfile.id, QUEST_TOTAL_CONNECTIONS),
-        incrementQuestProgress(connProfile.id, QUEST_TOTAL_CONNECTIONS)
+        db.put(userPut, PROFILES_TABLE, true)
+        // incrementQuestProgress(userProfile.id, QUEST_TOTAL_CONNECTIONS),
+        // incrementQuestProgress(connProfile.id, QUEST_TOTAL_CONNECTIONS)
       );
       break;
   }

--- a/services/interactions/helpers.js
+++ b/services/interactions/helpers.js
@@ -160,22 +160,21 @@ export const handleConnection = async (userID, connProfileID, timestamp) => {
 
     // case ATTENDEE:
     default:
-      promises.push(
-        db.put(connPut, PROFILES_TABLE, true),
-        db.put(userPut, PROFILES_TABLE, true)
-        // incrementQuestProgress(userProfile.id, QUEST_TOTAL_CONNECTIONS),
-        // incrementQuestProgress(connProfile.id, QUEST_TOTAL_CONNECTIONS)
-      );
+      try {
+        await db.putMultiple(
+          [connPut, userPut],
+          [PROFILES_TABLE, PROFILES_TABLE],
+          true
+        );
+      } catch (error) {
+        console.error(error);
+        return handlerHelpers.createResponse(500, {
+          message: "Internal server error"
+        });
+      }
+      // incrementQuestProgress(userProfile.id, QUEST_TOTAL_CONNECTIONS),
+      // incrementQuestProgress(connProfile.id, QUEST_TOTAL_CONNECTIONS)
       break;
-  }
-
-  try {
-    await Promise.all(promises);
-  } catch (error) {
-    console.error(error);
-    return handlerHelpers.createResponse(500, {
-      message: "Internal server error"
-    });
   }
 
   return handlerHelpers.createResponse(200, {

--- a/services/interactions/serverless.yml
+++ b/services/interactions/serverless.yml
@@ -67,25 +67,31 @@ functions:
           path: interactions/
           method: post
           cors: true
+          authorizer:
+            name: ${self:service}-authorizer
+            type: COGNITO_USER_POOLS
+            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+
   interactionJournalGetAll:
     handler: handler.getAllConnections
     events:
       - http:
-          path: interactions/journal/{id}
+          path: interactions/journal/
           method: get
-          request:
-            parameters:
-              path:
-                id: true
           cors: true
+          authorizer:
+            name: ${self:service}-authorizer
+            type: COGNITO_USER_POOLS
+            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+
   interactionQuestsGetAll:
     handler: handler.getAllQuests
     events:
       - http:
-          path: interactions/quests/{id}
+          path: interactions/quests/
           method: get
-          request:
-            parameters:
-              path:
-                id: true
           cors: true
+          authorizer:
+            name: ${self:service}-authorizer
+            type: COGNITO_USER_POOLS
+            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp

--- a/services/profiles/handler.js
+++ b/services/profiles/handler.js
@@ -227,18 +227,15 @@ export const getPublicProfile = async (event, ctx, callback) => {
     const { profileID } = event.pathParameters;
 
     // Query using the GSI
-    const result = await db.query(PROFILES_TABLE, null, {
-      expression: "compositeID = :compositeID AND #type = :profileType",
-      expressionValues: {
-        ":compositeID": `PROFILE#${profileID}`,
-        ":profileType": TYPES.PROFILE
-      },
-      expressionNames: {
-        "#type": "type"
+    const result = await db.getOneCustom({
+      TableName: PROFILES_TABLE + (process.env.ENVIRONMENT || ""),
+      Key: {
+        compositeID: `PROFILE#${profileID}`,
+        type: TYPES.PROFILE
       }
     });
 
-    if (!result || result.length === 0) {
+    if (!result) {
       throw helpers.notFoundResponse("Profile", profileID);
     }
 
@@ -266,18 +263,15 @@ export const getUserProfile = async (event, ctx, callback) => {
       throw helpers.notFoundResponse("Profile", userID);
     }
 
-    const result = await db.query(PROFILES_TABLE, null, {
-      expression: "compositeID = :compositeID AND #type = :profileType",
-      expressionValues: {
-        ":compositeID": `PROFILE#${profileID}`,
-        ":profileType": TYPES.PROFILE
-      },
-      expressionNames: {
-        "#type": "type"
+    const result = await db.getOneCustom({
+      TableName: PROFILES_TABLE + (process.env.ENVIRONMENT || ""),
+      Key: {
+        compositeID: `PROFILE#${profileID}`,
+        type: TYPES.PROFILE
       }
     });
 
-    if (!result || result.length === 0) {
+    if (!result) {
       throw helpers.notFoundResponse("Profile", profileID);
     }
 

--- a/services/profiles/handler.js
+++ b/services/profiles/handler.js
@@ -131,7 +131,7 @@ export const createPartialPartnerProfile = async (event, ctx, callback) => {
 
 export const updatePublicProfile = async (event, ctx, callback) => {
   try {
-    const userID = event.requestContext.authorizer.claims.email;
+    const userID = event.requestContext.authorizer.claims.email.toLowerCase();
     const body = JSON.parse(event.body);
     helpers.checkPayloadProps(body, {
       viewableMap: {
@@ -254,7 +254,7 @@ export const getPublicProfile = async (event, ctx, callback) => {
 
 export const getUserProfile = async (event, ctx, callback) => {
   try {
-    const userID = event.requestContext.authorizer.claims.email;
+    const userID = event.requestContext.authorizer.claims.email.toLowerCase();
 
     const member = await db.getOne(userID, MEMBERS2026_TABLE);
     const { profileID = null } = member || {};


### PR DESCRIPTION
## **Ticket(s):**
Issue #522

_DIFFS Profiles Rewrite_: this means once profiles-rewrite is merged, this should have the **base changed** to **dev**

## **Changes:**
POST **/interactions**
- still accepts same request body of eventType and eventParam, but the userID is now taken from the auth token
- commented out quests related functionality, currently writes new connection edges to profiles table under TYPE CONNECTION#connectionID
- only immutable fields are added in connection rows to prevent denormalization resulting in excessive writes

GET **/interactions/journal**
- remains similar in terms of response to blueprint, using the new table schema
- exact schema docs will be added to benny's api site once created


## Testing
_requesting all connections_
<img width="1394" height="503" alt="image" src="https://github.com/user-attachments/assets/8997d729-5215-4011-8798-978c07a6559d" />

_requesting new connection (too lazy to create new mock data, but logic works, rows attached below)_
<img width="1385" height="287" alt="image" src="https://github.com/user-attachments/assets/458d10a5-78c0-466c-9fcc-0354bbfadbbc" />
<img width="1318" height="79" alt="image" src="https://github.com/user-attachments/assets/3c7305ac-64a8-41de-af60-95eabf988be8" />

## Notes
- quests and other interactions (like badges) were not taken into scope for this ticket
- should be merged after profiles-rewrite
- may potentially require additional logic in partners section to create their profiles/maybe quests related to booths, however this should remain separate from connections
