### PR TITLE
Membership Price Refactor

### DIFF
--- a/services/payments/constants.js
+++ b/services/payments/constants.js
@@ -1,0 +1,1 @@
+export const MEMBERSHIP_PRICE = 1000; // cents

--- a/services/payments/handler.js
+++ b/services/payments/handler.js
@@ -11,6 +11,7 @@ import {
 } from "../../constants/tables";
 import { createProfile } from "../profiles/helpers";
 import { PROFILE_TYPES } from "../profiles/constants";
+import { MEMBERSHIP_PRICE } from "./constants";
 
 const stripe = require("stripe")(
   process.env.ENVIRONMENT === "PROD"
@@ -350,7 +351,10 @@ export const payment = async (event, ctx, callback) => {
               name: data.paymentName,
               images: paymentImages
             },
-            unit_amount: data.paymentPrice
+            unit_amount:
+              data.paymentType === "Event"
+                ? data.paymentPrice
+                : MEMBERSHIP_PRICE
           },
           quantity: 1
         }


### PR DESCRIPTION
**Changes:**

* Created a `constants.js` file with `MEMBERSHIP_PRICE`
* Stripe `unit_amount` now uses:

  * `data.paymentPrice` for `"Event"` payments
  * `MEMBERSHIP_PRICE` for `"OAuthMember"` (within a constant file)

**Reason:**

* Prevent price tampering from the frontend for memberships

**Note:**

* Events still allow dynamic pricing from frontend

**Related frontend PR:**

https://github.com/ubc-biztech/bt-web-v2/pull/225