### PR TITLE
Auth Refactor

### DIFF
--- a/services/events/serverless.yml
+++ b/services/events/serverless.yml
@@ -47,7 +47,6 @@ provider:
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechUsers${self:provider.environment.ENVIRONMENT}"
 
-
 custom: ${file(../../serverless.common.yml):custom}
 
 functions:
@@ -59,9 +58,8 @@ functions:
           method: post
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   eventDelete:
     handler: handler.del
     events:
@@ -74,9 +72,8 @@ functions:
               id: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   eventGetAll:
     handler: handler.getAll
     events:
@@ -101,9 +98,8 @@ functions:
               year: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   eventGet:
     handler: handler.get
     events:

--- a/services/hello/serverless.yml
+++ b/services/hello/serverless.yml
@@ -1,6 +1,5 @@
 # Always deploy the "hello" endpoint first (for any new environment)
 service: biztechApi
-tenant: ianmh
 app: biztechapp
 
 plugins:
@@ -35,6 +34,19 @@ functions:
 # Helps to share the endpoint between services
 # https://serverless-stack.com/chapters/share-an-api-endpoint-between-services.html
 resources:
+  Resources:
+    CognitoAuthorizer:
+      Type: AWS::ApiGateway::Authorizer
+      Properties:
+        Name: ${self:service}-authorizer
+        AuthorizerResultTtlInSeconds: 60
+        IdentitySource: method.request.header.Authorization
+        ProviderARNs:
+          - arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+        RestApiId:
+          "Fn::ImportValue": ${self:provider.stage}-ExtApiGatewayRestApiId
+        Type: COGNITO_USER_POOLS
+
   Outputs:
     ApiGatewayRestApiId:
       Value:
@@ -44,8 +56,14 @@ resources:
 
     ApiGatewayRestApiRootResourceId:
       Value:
-          Fn::GetAtt:
+        Fn::GetAtt:
           - ApiGatewayRestApi
           - RootResourceId
       Export:
         Name: ${self:provider.stage}-ExtApiGatewayRestApiRootResourceId
+
+    CognitoAuthorizer:
+      Value:
+        Ref: CognitoAuthorizer
+      Export:
+        Name: CognitoAuthorizer

--- a/services/interactions/serverless.yml
+++ b/services/interactions/serverless.yml
@@ -48,6 +48,7 @@ provider:
     - Effect: Allow
       Action:
         - dynamodb:GetItem
+        - dynamodb:QueryItem
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechProfiles${self:provider.environment.ENVIRONMENT}"
     - Effect: Allow

--- a/services/interactions/serverless.yml
+++ b/services/interactions/serverless.yml
@@ -56,12 +56,12 @@ provider:
         - dynamodb:GetItem
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechQRs${self:provider.environment.ENVIRONMENT}"
-      Effect: Allow
+    - Effect: Allow
       Action:
         - dynamodb:GetItem
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMembers${self:provider.environment.ENVIRONMENT}"
-      
+
 custom: ${file(../../serverless.common.yml):custom}
 
 functions:

--- a/services/interactions/serverless.yml
+++ b/services/interactions/serverless.yml
@@ -60,7 +60,7 @@ provider:
       Action:
         - dynamodb:GetItem
       Resource:
-        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMembers${self:provider.environment.ENVIRONMENT}"
+        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMembers2026${self:provider.environment.ENVIRONMENT}"
 
 custom: ${file(../../serverless.common.yml):custom}
 

--- a/services/interactions/serverless.yml
+++ b/services/interactions/serverless.yml
@@ -56,7 +56,12 @@ provider:
         - dynamodb:GetItem
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechQRs${self:provider.environment.ENVIRONMENT}"
-
+      Effect: Allow
+      Action:
+        - dynamodb:GetItem
+      Resource:
+        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMembers${self:provider.environment.ENVIRONMENT}"
+      
 custom: ${file(../../serverless.common.yml):custom}
 
 functions:

--- a/services/interactions/serverless.yml
+++ b/services/interactions/serverless.yml
@@ -48,7 +48,9 @@ provider:
     - Effect: Allow
       Action:
         - dynamodb:GetItem
-        - dynamodb:QueryItem
+        - dynamodb:Query
+        - dynamodb:PutItem
+        - dynamodb:TransactWriteItems
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechProfiles${self:provider.environment.ENVIRONMENT}"
     - Effect: Allow

--- a/services/interactions/serverless.yml
+++ b/services/interactions/serverless.yml
@@ -68,9 +68,8 @@ functions:
           method: post
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
 
   interactionJournalGetAll:
     handler: handler.getAllConnections
@@ -80,9 +79,8 @@ functions:
           method: get
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
 
   interactionQuestsGetAll:
     handler: handler.getAllQuests
@@ -92,6 +90,5 @@ functions:
           method: get
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}

--- a/services/members/serverless.yml
+++ b/services/members/serverless.yml
@@ -60,9 +60,8 @@ functions:
                 email: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   memberGetAll:
     handler: handler.getAll
     events:
@@ -71,9 +70,8 @@ functions:
           method: get
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   memberUpdate:
     handler: handler.update
     events:
@@ -85,9 +83,8 @@ functions:
               email: true
             cors: true
             authorizer:
-              name: ${self:service}-authorizer
               type: COGNITO_USER_POOLS
-              arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+              authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   memberDelete:
     handler: handler.del
     events:
@@ -99,6 +96,5 @@ functions:
               email: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}

--- a/services/payments/serverless.yml
+++ b/services/payments/serverless.yml
@@ -76,6 +76,14 @@ provider:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechEvents${self:provider.environment.ENVIRONMENT}"
     - Effect: Allow
       Action:
+        - dynamodb:GetItem
+        - dynamodb:Query
+        - dynamodb:PutItem
+        - dynamodb:TransactWriteItems
+      Resource:
+        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechProfiles${self:provider.environment.ENVIRONMENT}"
+    - Effect: Allow
+      Action:
         - sns:Publish
       Resource:
         - ${self:provider.environment.SNS_TOPIC_ARN}

--- a/services/prizes/serverless.yml
+++ b/services/prizes/serverless.yml
@@ -35,7 +35,6 @@ provider:
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechPrizes${self:provider.environment.ENVIRONMENT}"
 
-
 custom: ${file(../../serverless.common.yml):custom}
 
 functions:
@@ -47,9 +46,8 @@ functions:
           method: get
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   prizeCreate:
     handler: handler.create
     events:
@@ -58,9 +56,8 @@ functions:
           method: post
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   prizeUpdate:
     handler: handler.update
     events:
@@ -72,9 +69,8 @@ functions:
               id: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   prizeDelete:
     handler: handler.del
     events:
@@ -86,6 +82,5 @@ functions:
               id: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}

--- a/services/profiles/serverless.yml
+++ b/services/profiles/serverless.yml
@@ -44,9 +44,8 @@ functions:
           method: post
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
 
   createPartialPartnerProfile:
     handler: handler.createPartialPartnerProfile
@@ -100,9 +99,8 @@ functions:
           method: get
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
 
   updateUserProfile:
     handler: handler.updatePublicProfile
@@ -112,6 +110,5 @@ functions:
           method: patch
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}

--- a/services/qr/serverless.yml
+++ b/services/qr/serverless.yml
@@ -64,9 +64,8 @@ functions:
           method: get
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   qrGetOne:
     handler: handler.getOne
     events:
@@ -99,24 +98,20 @@ functions:
               year: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
 qrDelete:
-    handler: handler.del
-    events:
-      - http:
-          path: qr/{id}/{eventID}/{year}
-          method: delete
-          request:
-            path:
-              id: true
-              eventID: true
-              year: true
-          cors: true
-          authorizer:
-            name: ${self:service}-authorizer
-            type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
-
-
+  handler: handler.del
+  events:
+    - http:
+        path: qr/{id}/{eventID}/{year}
+        method: delete
+        request:
+          path:
+            id: true
+            eventID: true
+            year: true
+        cors: true
+        authorizer:
+          type: COGNITO_USER_POOLS
+          authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}

--- a/services/registrations/serverless.yml
+++ b/services/registrations/serverless.yml
@@ -99,9 +99,8 @@ functions:
               email: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   leaderboardGet:
     handler: handler.leaderboard
     events:

--- a/services/transactions/serverless.yml
+++ b/services/transactions/serverless.yml
@@ -37,7 +37,6 @@ provider:
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechTransactions${self:provider.environment.ENVIRONMENT}"
 
-
 custom: ${file(../../serverless.common.yml):custom}
 
 functions:
@@ -49,9 +48,8 @@ functions:
           method: get
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   transactionCreate:
     handler: handler.create
     events:
@@ -60,7 +58,5 @@ functions:
           method: post
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
-
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}

--- a/services/users/serverless.yml
+++ b/services/users/serverless.yml
@@ -89,9 +89,8 @@ functions:
                 email: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   userGetAll:
     handler: handler.getAll
     events:
@@ -100,9 +99,8 @@ functions:
           method: get
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   userUpdate:
     handler: handler.update
     events:
@@ -114,9 +112,8 @@ functions:
               email: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   userFavouriteEvent:
     handler: handler.favouriteEvent
     events:
@@ -128,9 +125,8 @@ functions:
               email: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   userDelete:
     handler: handler.del
     events:
@@ -142,7 +138,5 @@ functions:
               email: true
           cors: true
           authorizer:
-            name: ${self:service}-authorizer
             type: COGNITO_USER_POOLS
-            arn: arn:aws:cognito-idp:us-west-2:432714361962:userpool/us-west-2_w0R176hhp
-
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}


### PR DESCRIPTION
## **Ticket(s):**
Closes #525 

## **Changes:**
An issue came up when trying to deploy a service using an authorizer, where aws limits each account to a maximum of ten authorizers. Serverless by default creates a new authorizer for each service that calls one, which eventually leads to consistently failing CDs, despite using an identical authorizer configuration. 
- introduced shared CognitoAuthorizer resource in hello service (environment service)
- modified all services using their own authorizer to use the shared authorizer

## **Notes:**
- this process is relatively finnicky in terms of deleting resources to link them to the new shared authorizer
- merging to prod should be a safe process, there are only 8 existing authorizers, and when this deploys (hello needs to deploy first) all other authorizers can safely be reconfigured
- should also fix our CD issues

