### PR TITLE
Fix CI issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,18 +44,13 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           cd services
-          pids=()
-
           for DIR in *; do
-            cd "$DIR"
-            sls package --stage dev &
-            pid=$!
-            pids+=("$pid")
-            cd ..
-          done
-
-          for pid in "${pids[@]}"; do
-            wait "$pid" || exit 1
+            if [ -d "$DIR" ]; then
+              echo "Packaging service in $DIR..."
+              cd "$DIR"
+              sls package --stage dev || exit 1
+              cd ..
+            fi
           done
 
       - name: "Run Serverless Deployable to Production Check"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install Serverless CLI and dependencies
         run: |
-          sudo npm i -g serverless@3 --legacy-peer-deps
+          sudo npm i -g serverless --legacy-peer-deps
           npm ci --legacy-peer-deps
 
       - name: "Run Serverless Package Deployable Check"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Install Serverless CLI and dependencies
         run: |
           sudo npm i -g serverless --legacy-peer-deps
+          npm install --save-dev serverless-offline serverless-dynamodb
 
       - name: "Run Serverless Package Deployable Check"
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
             if [ -d "$DIR" ]; then
               echo "Packaging service in $DIR..."
               cd "$DIR"
+              npm ci --legacy-peer-deps
               sls package --stage dev || exit 1
               cd ..
             fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Install Serverless CLI and dependencies
         run: |
           sudo npm i -g serverless --legacy-peer-deps
-          npm ci --legacy-peer-deps
 
       - name: "Run Serverless Package Deployable Check"
         env:

--- a/services/bots/serverless.yml
+++ b/services/bots/serverless.yml
@@ -53,6 +53,9 @@ custom:
   slackEnabled: ${self:custom.slackEnabledMap.${self:custom.environment}, true}
   slackEnabledMap:
     PROD: false
+  
+build:
+  esbuild: false
 
 functions:
   discordInteractions:

--- a/services/events/serverless.yml
+++ b/services/events/serverless.yml
@@ -49,6 +49,9 @@ provider:
 
 custom: ${file(../../serverless.common.yml):custom}
 
+build:
+  esbuild: false
+
 functions:
   eventCreate:
     handler: handler.create

--- a/services/hello/serverless.yml
+++ b/services/hello/serverless.yml
@@ -22,6 +22,9 @@ provider:
 
 custom: ${file(../../serverless.common.yml):custom}
 
+build:
+  esbuild: false
+
 functions:
   hello:
     handler: handler.hello

--- a/services/interactions/serverless.yml
+++ b/services/interactions/serverless.yml
@@ -129,6 +129,9 @@ custom:
     stages:
       - dev
 
+build:
+  esbuild: false
+
 functions:
   interactionCreate:
     handler: handler.postInteraction

--- a/services/members/serverless.yml
+++ b/services/members/serverless.yml
@@ -38,6 +38,9 @@ provider:
 
 custom: ${file(../../serverless.common.yml):custom}
 
+build:
+  esbuild: false
+
 functions:
   memberCreate:
     handler: handler.create

--- a/services/payments/serverless.yml
+++ b/services/payments/serverless.yml
@@ -96,6 +96,9 @@ provider:
 
 custom: ${file(../../serverless.common.yml):custom}
 
+build:
+  esbuild: false
+
 functions:
   payment:
     handler: handler.payment

--- a/services/prizes/serverless.yml
+++ b/services/prizes/serverless.yml
@@ -37,6 +37,9 @@ provider:
 
 custom: ${file(../../serverless.common.yml):custom}
 
+build:
+  esbuild: false
+
 functions:
   prizeGetAll:
     handler: handler.getAll

--- a/services/profiles/serverless.yml
+++ b/services/profiles/serverless.yml
@@ -38,6 +38,9 @@ provider:
 
 custom: ${file(../../serverless.common.yml):custom}
 
+build:
+  esbuild: false
+
 functions:
   createProfile:
     handler: handler.create

--- a/services/qr/serverless.yml
+++ b/services/qr/serverless.yml
@@ -48,6 +48,9 @@ provider:
 
 custom: ${file(../../serverless.common.yml):custom}
 
+build:
+  esbuild: false
+
 functions:
   qrScan:
     handler: handler.post

--- a/services/registrations/serverless.yml
+++ b/services/registrations/serverless.yml
@@ -55,6 +55,8 @@ provider:
       Resource:
         - "arn:aws:sns:us-west-2:432714361962:slackbot"
 custom: ${file(../../serverless.common.yml):custom}
+build:
+  esbuild: false
 functions:
   registrationPost:
     handler: handler.post

--- a/services/stickers/serverless.yml
+++ b/services/stickers/serverless.yml
@@ -62,6 +62,9 @@ provider:
 
 custom: ${file(../../serverless.common.yml):custom}
 
+build:
+  esbuild: false
+
 functions:
   connectHandler:
     handler: handler.connectHandler

--- a/services/teams/serverless.yml
+++ b/services/teams/serverless.yml
@@ -71,6 +71,9 @@ provider:
 
 custom: ${file(../../serverless.common.yml):custom}
 
+build:
+  esbuild: false
+
 functions:
   updateTeamPoints:
     handler: handler.updateTeamPoints

--- a/services/transactions/serverless.yml
+++ b/services/transactions/serverless.yml
@@ -39,6 +39,9 @@ provider:
 
 custom: ${file(../../serverless.common.yml):custom}
 
+build:
+  esbuild: false
+
 functions:
   transactionGetAll:
     handler: handler.getAll

--- a/services/users/serverless.yml
+++ b/services/users/serverless.yml
@@ -47,6 +47,9 @@ provider:
 
 custom: ${file(../../serverless.common.yml):custom}
 
+build:
+  esbuild: false
+
 functions:
   userCreate:
     handler: handler.create


### PR DESCRIPTION
```
✖ ServerlessError2: Serverless now includes ESBuild and supports Typescript out-of-the-box. But this conflicts with the plugin 'serverless-bundle'.
You can either remove this plugin and try Serverless's ESBuild support builtin, or you can set 'build.esbuild' to false in your 'serverless.yml'.
```

Reproducing the CI issue locally. build.esbuild should be set to false.