### PR TITLE
Add required Algolia secrets to CI jobs

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -55,6 +55,8 @@ jobs:
           SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
           NODE_ENV: ${{ secrets.NODE_ENV }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
 
         # TODO: deploy all to production
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,8 @@ jobs:
           SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
           NODE_ENV: ${{ secrets.NODE_ENV }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
         run: |
           cd services
           pids=()
@@ -97,6 +99,8 @@ jobs:
           SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
           NODE_ENV: ${{ secrets.NODE_ENV }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
         run: |
           cd services
           pids=()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,8 @@ jobs:
           SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
           NODE_ENV: ${{ secrets.NODE_ENV }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
         run: |
           cd services
           pids=()


### PR DESCRIPTION
Currently, secrets are only added in the `test` workflow. Should be in all workflows