### PR TITLE
CI: Check eslint on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: autofix.ci
+name: Lint
 
 on:
   pull_request:
@@ -19,8 +19,36 @@ jobs:
           cache: "npm"
 
       - run: npm ci --legacy-peer-deps
-      - run: npx eslint . --fix
 
-      - uses: autofix-ci/action@551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef
+      - run: npx eslint .
+
+  pr-rules:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v7
         with:
-          commit-message: "Formatting with eslint"
+          script: |
+            const { data: commits } = await github.rest.pulls.listCommits({
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            if (commits.length !== 1) {
+              core.setFailed(`PR must have exactly 1 commit (has ${commits.length})`);
+            }
+
+            const msg = commits[0].commit.message;
+            const [subject, ...bodyLines] = msg.split('\n');
+
+            if (subject.length > 60) {
+              core.setFailed(`Commit subject must be ≤60 characters (got ${subject.length})`);
+            }
+
+            for (let i = 0; i < bodyLines.length; i++) {
+              const line = bodyLines[i];
+              if (line.length > 72) {
+                core.setFailed(`Commit body line ${i + 1} exceeds 72 characters: "${line.slice(0, 80)}..."`);
+              }
+            }


### PR DESCRIPTION
Runs npx eslint on every PR push to validate code quality without auto-fixing. Developers fix lint errors locally. Also enforces commit conventions: subject ≤60 chars, body lines ≤72 chars, exactly one commit per PR.