### PR TITLE
[BUG] Prevent registration errors from being double-wrapped

### DIFF
--- a/services/registrations/handler.js
+++ b/services/registrations/handler.js
@@ -379,7 +379,17 @@ export const post = async (event, ctx, callback) => {
     }
   } catch (err) {
     console.error(err);
-    return helpers.createResponse(500, { message: err.message || err });
+
+    // Known/intentional HTTP error
+    if (err?.statusCode && err?.body) {
+      return err;
+    }
+
+    // Unexpected internal error
+    return helpers.createResponse(500, {
+      message: err?.message || "Internal server error"
+    });
+
   }
 };
 
@@ -474,7 +484,13 @@ export const put = async (event, ctx, callback) => {
     return response;
   } catch (err) {
     console.error(err);
-    return helpers.createResponse(500, { message: err.message || err });
+    if (err?.statusCode && err?.body) {
+      return err;
+    }
+
+    return helpers.createResponse(500, {
+      message: err?.message || "Internal server error"
+    });
   }
 };
 
@@ -601,7 +617,13 @@ export const get = async (event, ctx, callback) => {
     });
   } catch (err) {
     console.error("Error in get handler:", err);
-    return helpers.createResponse(500, { message: err.message || err });
+    if (err?.statusCode && err?.body) {
+      return err;
+    }
+
+    return helpers.createResponse(500, {
+      message: err?.message || "Internal server error"
+    });
   }
 };
 
@@ -638,7 +660,13 @@ export const del = async (event, ctx, callback) => {
       response: res
     });
   } catch (err) {
-    return helpers.createResponse(500, { message: err.message || err });
+    if (err?.statusCode && err?.body) {
+      return err;
+    }
+
+    return helpers.createResponse(500, {
+      message: err?.message || "Internal server error"
+    });
   }
 };
 
@@ -689,7 +717,13 @@ export const delMany = async (event, ctx, callback) => {
       response: res
     });
   } catch (err) {
-    return helpers.createResponse(500, { message: err.message || err });
+    if (err?.statusCode && err?.body) {
+      return err;
+    }
+
+    return helpers.createResponse(500, {
+      message: err?.message || "Internal server error"
+    });
   }
 };
 
@@ -739,6 +773,11 @@ export const leaderboard = async (event, ctx, callback) => {
     }
   } catch (error) {
     console.error("Error fetching leaderboard:", error);
+
+    if (error?.statusCode && error?.body) {
+      return error;
+    }
+
     return {
       statusCode: 500,
       body: JSON.stringify({


### PR DESCRIPTION
Some HTTP error responses in registration handlers are wrapped in a new `500` response. These double-wrapped errors are super hard to phrase and predict on the frontend.

Was caught while testing a `406 Invalid email` bug, which was caught nested inside a `500` response. This produced an unexpected frontend error shape and caused React to attempt to render an object.
