### PR TITLE
[Feature] Update profileID reads and new createProfile() flow

### DIFF
--- a/services/interactions/handler.js
+++ b/services/interactions/handler.js
@@ -3,7 +3,7 @@
 //   OPENSEARCH_INDEX_TOP_K
 // } from "../../constants/indexes";
 import {
-  MEMBERS2026_TABLE,
+  USERS_TABLE,
   PROFILES_TABLE,
   EVENTS_TABLE
 } from "../../constants/tables";
@@ -104,9 +104,9 @@ export const checkConnection = async (event, ctx, callback) => {
 
     const connectionID = event.pathParameters.id;
     const userID = event.requestContext.authorizer.claims.email.toLowerCase();
-    const memberData = await db.getOne(userID, MEMBERS2026_TABLE);
+    const userData = await db.getOne(userID, USERS_TABLE);
 
-    if (!memberData)
+    if (!userData?.profileID)
       return helpers.createResponse(200, {
         message: `No profile associated with ${userID}`,
         connected: false
@@ -114,7 +114,7 @@ export const checkConnection = async (event, ctx, callback) => {
 
     const {
       profileID
-    } = memberData;
+    } = userData;
 
     if (connectionID == profileID)
       return helpers.createResponse(400, {
@@ -145,8 +145,12 @@ export const getAllConnections = async (event, ctx, callback) => {
   try {
     const userID = event.requestContext.authorizer.claims.email.toLowerCase();
 
-    const memberData = await db.getOne(userID, MEMBERS2026_TABLE);
-    const { profileID } = memberData;
+    const userData = await db.getOne(userID, USERS_TABLE);
+    const { profileID } = userData || {};
+
+    if (!profileID) {
+      throw helpers.notFoundResponse("Profile", userID);
+    }
 
     let data = await db.query(PROFILES_TABLE, null, {
       expression:

--- a/services/interactions/helpers.js
+++ b/services/interactions/helpers.js
@@ -8,7 +8,7 @@ import {
 } from "@aws-sdk/client-apigatewaymanagementapi";
 import {
   PROFILES_TABLE,
-  MEMBERS2026_TABLE
+  USERS_TABLE
 } from "../../constants/tables";
 import db from "../../lib/db";
 import handlerHelpers from "../../lib/handlerHelpers";
@@ -29,9 +29,13 @@ const LIVE_TABLE = `bizLiveConnections${process.env.ENVIRONMENT || ""}`;
 const WS_ENDPOINT = process.env.WS_API_ENDPOINT;
 
 export const handleConnection = async (userID, connProfileID, timestamp) => {
-  let memberData = await db.getOne(userID, MEMBERS2026_TABLE);
+  let userData = await db.getOne(userID, USERS_TABLE);
 
-  let userProfileID = memberData.profileID;
+  let userProfileID = userData?.profileID;
+
+  if (!userProfileID) {
+    throw handlerHelpers.notFoundResponse("Profile", userID);
+  }
 
   if (userProfileID === connProfileID) {
     return handlerHelpers.createResponse(400, {

--- a/services/interactions/serverless.yml
+++ b/services/interactions/serverless.yml
@@ -69,7 +69,7 @@ provider:
       Action:
         - dynamodb:GetItem
       Resource:
-        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMembers2026${self:provider.environment.ENVIRONMENT}"
+        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechUsers${self:provider.environment.ENVIRONMENT}"
     - Effect: Allow
       Action:
         - dynamodb:PutItem

--- a/services/members/handler.js
+++ b/services/members/handler.js
@@ -82,7 +82,7 @@ export const getEmailFromProfile = async (event, ctx, callback) => {
 
     const profileID = event.pathParameters.profileID;
 
-    const member = await db.query(MEMBERS2026_TABLE, "profile-query", {
+    const users = await db.query(USERS_TABLE, "profileID-index", {
       expression: "#profileID = :profileID",
       expressionNames: {
         "#profileID": "profileID"
@@ -92,10 +92,10 @@ export const getEmailFromProfile = async (event, ctx, callback) => {
       }
     });
 
-    if (isEmpty(member[0])) throw helpers.notFoundResponse("member", profileID);
-    console.log(member);
+    if (isEmpty(users[0])) throw helpers.notFoundResponse("user", profileID);
+    console.log(users);
 
-    const { id } = member[0];
+    const { id } = users[0];
 
     const response = helpers.createResponse(200, { email: id });
     return response;
@@ -304,8 +304,8 @@ export const grantMembership = async (event, ctx, callback) => {
       await db.put(memberParams, MEMBERS2026_TABLE, true);
     }
 
-    const memberWithProfile = await db.getOne(email, MEMBERS2026_TABLE);
-    if (!memberWithProfile || !memberWithProfile.profileID) {
+    const userWithProfile = await db.getOne(email, USERS_TABLE);
+    if (!userWithProfile || !userWithProfile.profileID) {
       await createProfile(
         email,
         isBiztechAdmin

--- a/services/members/serverless.yml
+++ b/services/members/serverless.yml
@@ -35,12 +35,10 @@ provider:
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
-        - dynamodb:Query
         - dynamodb:TransactWriteItems
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMembers2025${self:provider.environment.ENVIRONMENT}"
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMembers2026${self:provider.environment.ENVIRONMENT}"
-        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMembers2026${self:provider.environment.ENVIRONMENT}/index/profile-query"
     - Effect: Allow
       Action:
         - dynamodb:DeleteItem
@@ -55,8 +53,11 @@ provider:
         - dynamodb:GetItem
         - dynamodb:PutItem
         - dynamodb:UpdateItem
+        - dynamodb:Query
+        - dynamodb:TransactWriteItems
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechUsers${self:provider.environment.ENVIRONMENT}"
+        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechUsers${self:provider.environment.ENVIRONMENT}/index/profileID-index"
 
 custom: ${file(../../serverless.common.yml):custom}
 
@@ -148,4 +149,3 @@ functions:
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
-

--- a/services/payments/serverless.yml
+++ b/services/payments/serverless.yml
@@ -54,6 +54,7 @@ provider:
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
+        - dynamodb:TransactWriteItems
       Resource:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechUsers${self:provider.environment.ENVIRONMENT}"
     - Effect: Allow

--- a/services/profiles/handler.js
+++ b/services/profiles/handler.js
@@ -7,10 +7,8 @@ import {
   humanId
 } from "human-id";
 import {
-  PROFILES_TABLE
-} from "../../constants/tables.js";
-import {
-  MEMBERS2026_TABLE
+  PROFILES_TABLE,
+  USERS_TABLE
 } from "../../constants/tables.js";
 import {
   MUTABLE_PROFILE_ATTRIBUTES,
@@ -191,10 +189,10 @@ export const updatePublicProfile = async (event, ctx, callback) => {
       throw helpers.inputError("Viewable map is not a literal object", body);
     }
 
-    const member = await db.getOne(userID, MEMBERS2026_TABLE);
+    const user = await db.getOne(userID, USERS_TABLE);
     const {
       profileID = null
-    } = member || {
+    } = user || {
     };
 
     if (!profileID) {
@@ -300,10 +298,10 @@ export const getUserProfile = async (event, ctx, callback) => {
   try {
     const userID = event.requestContext.authorizer.claims.email.toLowerCase();
 
-    const member = await db.getOne(userID, MEMBERS2026_TABLE);
+    const user = await db.getOne(userID, USERS_TABLE);
     const {
       profileID = null
-    } = member || {
+    } = user || {
     };
 
     if (!profileID) {
@@ -452,8 +450,8 @@ export const createProfilePicUploadUrl = async (event, ctx, callback) => {
 
     let profileId = event.queryStringParameters?.profileId;
     if (!profileId) {
-      const member = await db.getOne(userEmail, MEMBERS2026_TABLE);
-      profileId = member?.profileID;
+      const user = await db.getOne(userEmail, USERS_TABLE);
+      profileId = user?.profileID;
     }
     if (!profileId) {
       return helpers.createResponse(400, {

--- a/services/profiles/helpers.js
+++ b/services/profiles/helpers.js
@@ -1,6 +1,6 @@
 import humanId from "human-id";
 import {
-  MEMBERS2026_TABLE, PROFILES_TABLE
+  MEMBERS2026_TABLE, PROFILES_TABLE, USERS_TABLE
 } from "../../constants/tables";
 import db from "../../lib/db";
 import helpers from "../../lib/handlerHelpers";
@@ -9,14 +9,20 @@ import {
 } from "./constants";
 
 export async function createProfile(email, profileType) {
-  const memberData = await db.getOne(email, MEMBERS2026_TABLE);
+  const [memberData, userData] = await Promise.all([
+    db.getOne(email, MEMBERS2026_TABLE),
+    db.getOne(email, USERS_TABLE)
+  ]);
 
-  // Check if profile already exists, member entry implies profile entry
   if (!memberData) {
-    throw helpers.notFoundResponse("id", email);
+    throw helpers.notFoundResponse("member", email);
   }
 
-  if (memberData.profileID) {
+  if (!userData) {
+    throw helpers.notFoundResponse("user", email);
+  }
+
+  if (userData.profileID) {
     throw helpers.duplicateResponse("Profile", email);
   }
 
@@ -47,6 +53,7 @@ export async function createProfile(email, profileType) {
   const profile = {
     compositeID: `PROFILE#${profileID}`,
     type: TYPES.PROFILE,
+    profileID,
     fname: memberData.firstName,
     lname: memberData.lastName,
     pronouns: memberData.pronouns || "",
@@ -70,14 +77,15 @@ export async function createProfile(email, profileType) {
     Key: {
       id: email
     },
-    TableName: MEMBERS2026_TABLE + (process.env.ENVIRONMENT || ""),
+    TableName: USERS_TABLE + (process.env.ENVIRONMENT || ""),
     UpdateExpression: "set profileID = :profileID, updatedAt = :updatedAt",
     ExpressionAttributeValues: {
       ":profileID": profileID,
       ":updatedAt": timestamp
     },
     ReturnValues: "UPDATED_NEW",
-    ConditionExpression: "attribute_exists(id)"
+    ConditionExpression:
+      "attribute_exists(id) AND attribute_not_exists(profileID)"
   };
 
   const {
@@ -92,13 +100,13 @@ export async function createProfile(email, profileType) {
       Put: {
         TableName: PROFILES_TABLE,
         Item: profile,
-        ConditionExpression: "attribute_not_exists(id)"
+        ConditionExpression: "attribute_not_exists(compositeID)"
       }
     },
     {
       Update: {
         ...updateParams,
-        TableName: MEMBERS2026_TABLE,
+        TableName: USERS_TABLE,
         Key: {
           id: email
         }

--- a/services/profiles/serverless.yml
+++ b/services/profiles/serverless.yml
@@ -33,10 +33,12 @@ provider:
         - dynamodb:UpdateItem
         - dynamodb:Query
         - dynamodb:Scan
+        - dynamodb:TransactWriteItems
         - s3:PutObject
       Resource:
         - "arn:aws:dynamodb:${aws:region}:*:table/biztechProfiles${self:provider.environment.ENVIRONMENT}"
         - "arn:aws:dynamodb:${aws:region}:*:table/biztechMembers2026${self:provider.environment.ENVIRONMENT}"
+        - "arn:aws:dynamodb:${aws:region}:*:table/biztechUsers${self:provider.environment.ENVIRONMENT}"
         - "arn:aws:s3:::biztech-profile-pictures/profile-pictures/*"
 
 custom: ${file(../../serverless.common.yml):custom}

--- a/services/quests/handler.ts
+++ b/services/quests/handler.ts
@@ -1,4 +1,4 @@
-import { MEMBERS2026_TABLE, QUESTS_TABLE } from "../../constants/tables.js";
+import { QUESTS_TABLE, USERS_TABLE } from "../../constants/tables.js";
 import db from "../../lib/db.js";
 import handlerHelpers from "../../lib/handlerHelpers";
 import type { APIGatewayEvent, LambdaCallback, LambdaContext } from "../../lib/types";
@@ -7,7 +7,7 @@ import { applyQuestEvent, initStoredQuest, parseEvents } from "./helper.js";
 
 async function getEmailFromProfileId(profileId: string): Promise<string | null> {
   try {
-    const results = await db.query(MEMBERS2026_TABLE, "profile-query", {
+    const results = await db.query(USERS_TABLE, "profileID-index", {
       expression: "#profileID = :profileID",
       expressionNames: {
         "#profileID": "profileID",
@@ -255,10 +255,10 @@ export const updateQuest = async (
         if (userBEmailLower !== userID) {
           let userAProfileId: string | null = null;
           try {
-            const userAMember = await db.getOne(userID, MEMBERS2026_TABLE);
+            const userA = await db.getOne(userID, USERS_TABLE);
             userAProfileId =
-              userAMember && (userAMember.profileID as string | undefined)
-                ? (userAMember.profileID as string)
+              userA && (userA.profileID as string | undefined)
+                ? (userA.profileID as string)
                 : null;
           } catch (_e: unknown) {
             console.warn(`Could not get profileId for ${userID}`);
@@ -431,7 +431,7 @@ async function resolveEmailFromProfileId(
   if (!profileId) return null;
 
   try {
-    const results = await db.query(MEMBERS2026_TABLE, "profile-query", {
+    const results = await db.query(USERS_TABLE, "profileID-index", {
       expression: "#profileID = :profileID",
       expressionNames: {
         "#profileID": "profileID",

--- a/services/quests/serverless.yml
+++ b/services/quests/serverless.yml
@@ -41,10 +41,11 @@ provider:
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechQuests${self:provider.environment.ENVIRONMENT}/index/event-query"
     - Effect: Allow
       Action:
+        - dynamodb:GetItem
         - dynamodb:Query
       Resource:
-        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMembers2026${self:provider.environment.ENVIRONMENT}"
-        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechMembers2026${self:provider.environment.ENVIRONMENT}/index/profile-query"
+        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechUsers${self:provider.environment.ENVIRONMENT}"
+        - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechUsers${self:provider.environment.ENVIRONMENT}/index/profileID-index"
         - "arn:aws:dynamodb:us-west-2:432714361962:table/biztechProfiles${self:provider.environment.ENVIRONMENT}"
 
 custom: ${file(../../serverless.common.yml):custom}


### PR DESCRIPTION
- Profile reads now resolve profileID from biztechUsers.profileID
- Reverse lookups now query biztechUsers profileID (instead of biztechMembers2026)
- createProfile() now checks/writes profileID on biztechUsers, not the membership table
- IAM/serverless permissions were updated for users table reads, profileID-index queries, and user-table transaction writes.
