### PR TITLE
UBC-43 Add partner ingestion batch endpoints

### DIFF
--- a/services/members/handler.js
+++ b/services/members/handler.js
@@ -3,13 +3,18 @@ import db from "../../lib/db";
 import { isEmpty, isValidEmail } from "../../lib/utils";
 import {
   USERS_TABLE,
-  MEMBERS_TABLE
+  MEMBERS_TABLE,
+  PROFILES_TABLE
 } from "../../constants/tables";
 import {
   createProfile,
   updateProfileFromMembershipData
 } from "../profiles/helpers";
-import { PROFILE_TYPES } from "../profiles/constants";
+import {
+  PROFILE_TYPES,
+  TYPES
+} from "../profiles/constants";
+import humanId from "human-id";
 
 const validProfileTypes = new Set(Object.values(PROFILE_TYPES));
 
@@ -27,6 +32,158 @@ const normalizeTopics = (topics) =>
   (Array.isArray(topics) ? topics : (topics || "").split(","))
     .map((topic) => topic.trim())
     .filter(Boolean);
+
+const PARTNER_PROFILE_VIEWABLE_MAP = {
+  fname: true,
+  lname: true,
+  pronouns: true,
+  major: false,
+  year: false,
+  profileType: true,
+  hobby1: false,
+  hobby2: false,
+  funQuestion1: false,
+  funQuestion2: false,
+  linkedIn: true,
+  profilePictureURL: false,
+  additionalLink: false,
+  resumeURL: false,
+  description: false,
+  company: true,
+  position: true
+};
+
+const normalizePartner = (partner = {}) => ({
+  email: partner.email ? partner.email.trim().toLowerCase() : "",
+  firstName: (partner.firstName || partner.fname || "").trim(),
+  lastName: (partner.lastName || partner.lname || "").trim(),
+  pronouns: (partner.pronouns || "").trim(),
+  linkedIn: (partner.linkedIn || partner.linkedin || "").trim(),
+  company: (partner.company || "").trim(),
+  position: (partner.position || "").trim()
+});
+
+const validatePartner = (partner) => {
+  if (!isValidEmail(partner.email)) return "Invalid email";
+  if (!partner.firstName) return "Missing firstName";
+  if (!partner.lastName) return "Missing lastName";
+  return null;
+};
+
+const summarizePartnerResults = (results) => {
+  return results.reduce(
+    (summary, result) => {
+      summary[result.status] += 1;
+      return summary;
+    },
+    {
+      created: 0,
+      skipped: 0,
+      failed: 0
+    }
+  );
+};
+
+const buildPartnerMembershipRecords = (partner, profileID, timestamp) => {
+  const user = {
+    id: partner.email,
+    fname: partner.firstName,
+    lname: partner.lastName,
+    isMember: true,
+    admin: partner.email.endsWith("@ubcbiztech.com"),
+    profileID,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+
+  const member = {
+    id: partner.email,
+    cardCount: 0,
+    firstName: partner.firstName,
+    lastName: partner.lastName,
+    pronouns: partner.pronouns,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+
+  const profile = {
+    compositeID: `PROFILE#${profileID}`,
+    type: TYPES.PROFILE,
+    profileID,
+    fname: partner.firstName,
+    lname: partner.lastName,
+    pronouns: partner.pronouns,
+    linkedIn: partner.linkedIn,
+    company: partner.company,
+    position: partner.position,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    profileType: PROFILE_TYPES.PARTNER,
+    viewableMap: PARTNER_PROFILE_VIEWABLE_MAP
+  };
+
+  return {
+    user,
+    member,
+    profile
+  };
+};
+
+const buildPartnerMembershipTransaction = (records, existingUser) => {
+  const userWrite = isEmpty(existingUser)
+    ? {
+      Put: {
+        TableName: USERS_TABLE,
+        Item: records.user,
+        ConditionExpression: "attribute_not_exists(id)"
+      }
+    }
+    : {
+      Update: {
+        TableName: USERS_TABLE,
+        Key: {
+          id: records.user.id
+        },
+        UpdateExpression:
+          "SET #fname = :fname, #lname = :lname, #isMember = :isMember, #admin = :admin, #profileID = :profileID, #updatedAt = :updatedAt",
+        ExpressionAttributeNames: {
+          "#fname": "fname",
+          "#lname": "lname",
+          "#isMember": "isMember",
+          "#admin": "admin",
+          "#profileID": "profileID",
+          "#updatedAt": "updatedAt"
+        },
+        ExpressionAttributeValues: {
+          ":fname": records.user.fname,
+          ":lname": records.user.lname,
+          ":isMember": true,
+          ":admin": records.user.admin,
+          ":profileID": records.user.profileID,
+          ":updatedAt": records.user.updatedAt
+        },
+        ConditionExpression: "attribute_exists(id)"
+      }
+    };
+
+  return [
+    userWrite,
+    {
+      Put: {
+        TableName: MEMBERS_TABLE,
+        Item: records.member,
+        ConditionExpression: "attribute_not_exists(id)"
+      }
+    },
+    {
+      Put: {
+        TableName: PROFILES_TABLE,
+        Item: records.profile,
+        ConditionExpression: "attribute_not_exists(compositeID)"
+      }
+    }
+  ];
+};
 
 export const create = async (event, ctx, callback) => {
   const userID = event.requestContext.authorizer.claims.email.toLowerCase();
@@ -232,6 +389,86 @@ export const del = async (event, ctx, callback) => {
   }
 };
 
+export const createPartnerMemberships = async (event, ctx, callback) => {
+  try {
+    const userID = event.requestContext.authorizer.claims.email.toLowerCase();
+    if (!userID.endsWith("@ubcbiztech.com")) {
+      return helpers.createResponse(403, {
+        message: "unauthorized"
+      });
+    }
+
+    const data = JSON.parse(event.body || "{}");
+    if (!Array.isArray(data.partners)) {
+      return helpers.inputError("partners must be an array", data);
+    }
+
+    const results = await Promise.all(data.partners.map(async (partnerData) => {
+      const partner = normalizePartner(partnerData);
+      const validationError = validatePartner(partner);
+      if (validationError) {
+        return {
+          email: partner.email,
+          status: "failed",
+          reason: validationError
+        };
+      }
+
+      const existingMember = await db.getOne(partner.email, MEMBERS_TABLE);
+      if (!isEmpty(existingMember)) {
+        return {
+          email: partner.email,
+          status: "skipped",
+          reason: "membership already exists"
+        };
+      }
+
+      const profileID = humanId();
+      const timestamp = new Date().getTime();
+      const records = buildPartnerMembershipRecords(
+        partner,
+        profileID,
+        timestamp
+      );
+      const existingUser = await db.getOne(partner.email, USERS_TABLE);
+      const transactionItems = buildPartnerMembershipTransaction(
+        records,
+        existingUser
+      );
+
+      try {
+        await db.writeMultiple(transactionItems);
+
+        return {
+          email: partner.email,
+          status: "created",
+          profileID
+        };
+      } catch (err) {
+        const body = err && err.body ? JSON.parse(err.body) : {};
+        return {
+          email: partner.email,
+          status: "failed",
+          reason:
+            body.code ||
+            (err && err.message) ||
+            "Failed to create partner membership"
+        };
+      }
+    }));
+
+    return helpers.createResponse(200, {
+      ...summarizePartnerResults(results),
+      results
+    });
+  } catch (err) {
+    console.error(err);
+    return helpers.createResponse(500, {
+      message: err.message || "Internal server error"
+    });
+  }
+};
+
 // type CreateMemberRequest = {
 //   email: string,
 //   firstName: string,
@@ -262,7 +499,7 @@ export const grantMembership = async (event, ctx, callback) => {
 
     const data = JSON.parse(event.body);
 
-    const email = data?.email?.toLowerCase();
+    const email = data && data.email ? data.email.toLowerCase() : undefined;
     if (!isValidEmail(email)) {
       callback(null, helpers.inputError("Invalid email", email));
       return null;
@@ -328,7 +565,7 @@ export const grantMembership = async (event, ctx, callback) => {
     }
 
     const userWithProfile = await db.getOne(email, USERS_TABLE);
-    if (userWithProfile?.profileID) {
+    if (userWithProfile && userWithProfile.profileID) {
       await updateProfileFromMembershipData(
         userWithProfile.profileID,
         memberDataForProfile

--- a/services/members/serverless.yml
+++ b/services/members/serverless.yml
@@ -150,3 +150,14 @@ functions:
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
+
+  memberCreatePartnerMemberships:
+    handler: handler.createPartnerMemberships
+    events:
+      - http:
+          path: members/partners/batch
+          method: post
+          cors: true
+          authorizer:
+            type: COGNITO_USER_POOLS
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}

--- a/services/members/test/memberCreatePartnerMemberships.js
+++ b/services/members/test/memberCreatePartnerMemberships.js
@@ -1,0 +1,264 @@
+"use strict";
+
+// tests for memberCreatePartnerMemberships
+
+import mochaPlugin from "serverless-mocha-plugin";
+const expect = mochaPlugin.chai.expect;
+import {
+  mockClient
+} from "aws-sdk-client-mock";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  TransactWriteCommand
+} from "@aws-sdk/lib-dynamodb";
+import {
+  MEMBERS_TABLE,
+  PROFILES_TABLE,
+  USERS_TABLE
+} from "../../../constants/tables";
+
+let wrapped = mochaPlugin.getWrapper(
+  "memberCreatePartnerMemberships",
+  "/handler.js",
+  "createPartnerMemberships"
+);
+
+const adminEmail = "admin@ubcbiztech.com";
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+const buildEvent = ({ email, body }) => ({
+  requestContext: {
+    authorizer: {
+      claims: {
+        email
+      }
+    }
+  },
+  body: JSON.stringify(body)
+});
+
+describe("memberCreatePartnerMemberships", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+  });
+
+  afterEach(() => {
+    ddbMock.restore();
+  });
+
+  it("returns 403 when caller is not a BizTech admin", async () => {
+    const response = await wrapped.run(
+      buildEvent({
+        email: "student@gmail.com",
+        body: {
+          partners: []
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(403);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.message).to.equal("unauthorized");
+  });
+
+  it("returns 406 when partners is not an array", async () => {
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {}
+      })
+    );
+
+    expect(response.statusCode).to.equal(406);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.message).to.equal("partners must be an array");
+  });
+
+  it("marks invalid partner rows as failed", async () => {
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          partners: [
+            {
+              email: "not-an-email",
+              firstName: "Ada",
+              lastName: "Lovelace"
+            }
+          ]
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(200);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.created).to.equal(0);
+    expect(responseBody.skipped).to.equal(0);
+    expect(responseBody.failed).to.equal(1);
+    expect(responseBody.results[0].email).to.equal("not-an-email");
+    expect(responseBody.results[0].status).to.equal("failed");
+    expect(responseBody.results[0].reason).to.equal("Invalid email");
+  });
+
+  it("skips partner rows when membership already exists", async () => {
+    const partnerEmail = "partner@example.com";
+
+    ddbMock.on(GetCommand).callsFake((params) => {
+      if (
+        params.TableName.includes(MEMBERS_TABLE) &&
+        params.Key.id === partnerEmail
+      ) {
+        return {
+          Item: {
+            id: partnerEmail
+          }
+        };
+      }
+
+      return {
+        Item: null
+      };
+    });
+
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          partners: [
+            {
+              email: partnerEmail,
+              firstName: "Grace",
+              lastName: "Hopper"
+            }
+          ]
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(200);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.created).to.equal(0);
+    expect(responseBody.skipped).to.equal(1);
+    expect(responseBody.failed).to.equal(0);
+    expect(responseBody.results[0].email).to.equal(partnerEmail);
+    expect(responseBody.results[0].status).to.equal("skipped");
+    expect(responseBody.results[0].reason).to.equal(
+      "membership already exists"
+    );
+  });
+
+  it("creates user member and profile records for a valid partner", async () => {
+    const partnerEmail = "partner@example.com";
+    let transactionItems = [];
+
+    ddbMock.on(GetCommand).resolves({
+      Item: null
+    });
+
+    ddbMock.on(TransactWriteCommand).callsFake((params) => {
+      transactionItems = params.TransactItems;
+      return {};
+    });
+
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          partners: [
+            {
+              email: partnerEmail,
+              firstName: "Katherine",
+              lastName: "Johnson",
+              pronouns: "She/Her",
+              company: "NASA",
+              position: "Mathematician",
+              linkedIn: "https://linkedin.com/in/katherine"
+            }
+          ]
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(200);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.created).to.equal(1);
+    expect(responseBody.skipped).to.equal(0);
+    expect(responseBody.failed).to.equal(0);
+    expect(responseBody.results[0].email).to.equal(partnerEmail);
+    expect(responseBody.results[0].status).to.equal("created");
+    expect(responseBody.results[0].profileID).to.not.be.empty;
+
+    expect(transactionItems).to.have.lengthOf(3);
+
+    const userWrite = transactionItems.find((item) =>
+      item.Put && item.Put.TableName.includes(USERS_TABLE)
+    );
+    const memberWrite = transactionItems.find((item) =>
+      item.Put && item.Put.TableName.includes(MEMBERS_TABLE)
+    );
+    const profileWrite = transactionItems.find((item) =>
+      item.Put && item.Put.TableName.includes(PROFILES_TABLE)
+    );
+
+    expect(userWrite.Put.Item.id).to.equal(partnerEmail);
+    expect(userWrite.Put.Item.fname).to.equal("Katherine");
+    expect(userWrite.Put.Item.lname).to.equal("Johnson");
+    expect(userWrite.Put.Item.isMember).to.equal(true);
+    expect(userWrite.Put.Item.profileID).to.equal(
+      responseBody.results[0].profileID
+    );
+
+    expect(memberWrite.Put.Item.id).to.equal(partnerEmail);
+    expect(memberWrite.Put.Item.firstName).to.equal("Katherine");
+    expect(memberWrite.Put.Item.lastName).to.equal("Johnson");
+    expect(memberWrite.Put.Item.cardCount).to.equal(0);
+
+    expect(profileWrite.Put.Item.profileID).to.equal(
+      responseBody.results[0].profileID
+    );
+    expect(profileWrite.Put.Item.fname).to.equal("Katherine");
+    expect(profileWrite.Put.Item.lname).to.equal("Johnson");
+    expect(profileWrite.Put.Item.company).to.equal("NASA");
+    expect(profileWrite.Put.Item.position).to.equal("Mathematician");
+  });
+
+  it("marks partner rows as failed when the transaction write fails", async () => {
+    const partnerEmail = "partner@example.com";
+
+    ddbMock.on(GetCommand).resolves({
+      Item: null
+    });
+
+    ddbMock.on(TransactWriteCommand).rejects({
+      code: "TransactionCanceledException",
+      message: "Transaction cancelled"
+    });
+
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          partners: [
+            {
+              email: partnerEmail,
+              firstName: "Dorothy",
+              lastName: "Vaughan"
+            }
+          ]
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(200);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.created).to.equal(0);
+    expect(responseBody.skipped).to.equal(0);
+    expect(responseBody.failed).to.equal(1);
+    expect(responseBody.results[0].email).to.equal(partnerEmail);
+    expect(responseBody.results[0].status).to.equal("failed");
+    expect(responseBody.results[0].reason).to.equal(
+      "TransactionCanceledException"
+    );
+  });
+});

--- a/services/registrations/handler.js
+++ b/services/registrations/handler.js
@@ -14,6 +14,33 @@ import awsConfig from "../../lib/config";
 
 // const CHECKIN_COUNT_SANITY_CHECK = 500;
 
+const normalizePartnerRegistration = (partner = {}) => ({
+  email: partner.email ? partner.email.trim().toLowerCase() : "",
+  firstName: (partner.firstName || partner.fname || "").trim(),
+  lastName: (partner.lastName || partner.lname || "").trim()
+});
+
+const validatePartnerRegistration = (partner) => {
+  if (!isValidEmail(partner.email)) return "Invalid email";
+  if (!partner.firstName) return "Missing firstName";
+  if (!partner.lastName) return "Missing lastName";
+  return null;
+};
+
+const summarizePartnerRegistrationResults = (results) => {
+  return results.reduce(
+    (summary, result) => {
+      summary[result.status] += 1;
+      return summary;
+    },
+    {
+      created: 0,
+      skipped: 0,
+      failed: 0
+    }
+  );
+};
+
 /* returns error 403 if the given id/eventID DNE in database
    returns error 502 if there is a problem with processing data or sending an email
    returns 201 when entry is created successfully, error 409 if a registration with the same id/eventID exists
@@ -381,13 +408,119 @@ export const post = async (event, ctx, callback) => {
     console.error(err);
 
     // Known/intentional HTTP error
-    if (err?.statusCode && err?.body) {
+    if (err && err.statusCode && err.body) {
       return err;
     }
 
     // Unexpected internal error
     return helpers.createResponse(500, {
-      message: err?.message || "Internal server error"
+      message: (err && err.message) || "Internal server error"
+    });
+  }
+};
+
+export const createPartnerRegistrations = async (event, ctx, callback) => {
+  try {
+    const userID = event.requestContext.authorizer.claims.email.toLowerCase();
+    if (!userID.endsWith("@ubcbiztech.com")) {
+      return helpers.createResponse(403, {
+        message: "unauthorized"
+      });
+    }
+
+    const data = JSON.parse(event.body || "{}");
+    const { eventID, year } = data;
+
+    if (typeof eventID !== "string") {
+      return helpers.inputError("eventID must be a string", data);
+    }
+
+    if (typeof year !== "number" || isNaN(year)) {
+      return helpers.inputError("year must be a number", data);
+    }
+
+    if (!Array.isArray(data.partners)) {
+      return helpers.inputError("partners must be an array", data);
+    }
+
+    const existingEvent = await db.getOne(eventID, EVENTS_TABLE, {
+      year
+    });
+    if (isEmpty(existingEvent)) {
+      return helpers.createResponse(404, {
+        message: `Event with id '${eventID}' and year '${year}' could not be found.`
+      });
+    }
+
+    const results = await Promise.all(data.partners.map(async (partnerData) => {
+      const partner = normalizePartnerRegistration(partnerData);
+      const validationError = validatePartnerRegistration(partner);
+      if (validationError) {
+        return {
+          email: partner.email,
+          status: "failed",
+          reason: validationError
+        };
+      }
+
+      const existingRegistration = await db.getOne(
+        partner.email,
+        USER_REGISTRATIONS_TABLE,
+        {
+          "eventID;year": `${eventID};${year}`
+        }
+      );
+      if (!isEmpty(existingRegistration)) {
+        return {
+          email: partner.email,
+          status: "skipped",
+          reason: "registration already exists"
+        };
+      }
+
+      try {
+        await updateHelper(
+          {
+            eventID,
+            year,
+            email: partner.email,
+            fname: partner.firstName,
+            registrationStatus: "acceptedComplete",
+            isPartner: true
+          },
+          true,
+          partner.email,
+          partner.firstName
+        );
+
+        return {
+          email: partner.email,
+          status: "created"
+        };
+      } catch (err) {
+        const body = err && err.body ? JSON.parse(err.body) : {};
+        return {
+          email: partner.email,
+          status: "failed",
+          reason:
+            body.code ||
+            body.message ||
+            (err && err.message) ||
+            "Failed to create partner registration"
+        };
+      }
+    }));
+
+    return helpers.createResponse(200, {
+      eventID,
+      year,
+      ...summarizePartnerRegistrationResults(results),
+      results
+    });
+  } catch (err) {
+    console.error(err);
+    return helpers.createResponse(500, {
+      message: err.message || "Internal server error"
     });
   }
 };
@@ -464,8 +597,12 @@ export const put = async (event, ctx, callback) => {
       // for type safety, but event pricing not existing for nonMember
       // with a nonMember registration is an illegal state
       const pricing = isMember
-        ? eventExists.pricing?.members ?? 0
-        : eventExists.pricing?.nonMembers ?? 0;
+        ? eventExists.pricing && eventExists.pricing.members != null
+          ? eventExists.pricing.members
+          : 0
+        : eventExists.pricing && eventExists.pricing.nonMembers != null
+          ? eventExists.pricing.nonMembers
+          : 0;
 
       // Set status to complete if pricing is free or zero
       if (pricing === 0) {
@@ -483,12 +620,12 @@ export const put = async (event, ctx, callback) => {
     return response;
   } catch (err) {
     console.error(err);
-    if (err?.statusCode && err?.body) {
+    if (err && err.statusCode && err.body) {
       return err;
     }
 
     return helpers.createResponse(500, {
-      message: err?.message || "Internal server error"
+      message: (err && err.message) || "Internal server error"
     });
   }
 };
@@ -616,12 +753,12 @@ export const get = async (event, ctx, callback) => {
     });
   } catch (err) {
     console.error("Error in get handler:", err);
-    if (err?.statusCode && err?.body) {
+    if (err && err.statusCode && err.body) {
       return err;
     }
 
     return helpers.createResponse(500, {
-      message: err?.message || "Internal server error"
+      message: (err && err.message) || "Internal server error"
     });
   }
 };
@@ -659,12 +796,12 @@ export const del = async (event, ctx, callback) => {
       response: res
     });
   } catch (err) {
-    if (err?.statusCode && err?.body) {
+    if (err && err.statusCode && err.body) {
       return err;
     }
 
     return helpers.createResponse(500, {
-      message: err?.message || "Internal server error"
+      message: (err && err.message) || "Internal server error"
     });
   }
 };
@@ -716,12 +853,12 @@ export const delMany = async (event, ctx, callback) => {
       response: res
     });
   } catch (err) {
-    if (err?.statusCode && err?.body) {
+    if (err && err.statusCode && err.body) {
       return err;
     }
 
     return helpers.createResponse(500, {
-      message: err?.message || "Internal server error"
+      message: (err && err.message) || "Internal server error"
     });
   }
 };
@@ -773,7 +910,7 @@ export const leaderboard = async (event, ctx, callback) => {
   } catch (error) {
     console.error("Error fetching leaderboard:", error);
 
-    if (error?.statusCode && error?.body) {
+    if (error && error.statusCode && error.body) {
       return error;
     }
 

--- a/services/registrations/serverless.yml
+++ b/services/registrations/serverless.yml
@@ -70,6 +70,16 @@ functions:
           path: registrations/
           method: post
           cors: true
+  registrationCreatePartnerRegistrations:
+    handler: handler.createPartnerRegistrations
+    events:
+      - http:
+          path: registrations/partners/batch
+          method: post
+          cors: true
+          authorizer:
+            type: COGNITO_USER_POOLS
+            authorizerId: ${cf:biztechApi-${file(../../serverless.common.yml):provider.stage}.CognitoAuthorizer}
   registrationPut:
     handler: handler.put
     events:

--- a/services/registrations/test/registrationCreatePartnerRegistrations.js
+++ b/services/registrations/test/registrationCreatePartnerRegistrations.js
@@ -1,0 +1,385 @@
+"use strict";
+
+// tests for registrationCreatePartnerRegistrations
+
+import mochaPlugin from "serverless-mocha-plugin";
+const expect = mochaPlugin.chai.expect;
+import {
+  mockClient
+} from "aws-sdk-client-mock";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  UpdateCommand
+} from "@aws-sdk/lib-dynamodb";
+import {
+  SNSClient,
+  PublishCommand
+} from "@aws-sdk/client-sns";
+import {
+  EVENTS_TABLE,
+  USER_REGISTRATIONS_TABLE
+} from "../../../constants/tables";
+
+let wrapped = mochaPlugin.getWrapper(
+  "registrationCreatePartnerRegistrations",
+  "/handler.js",
+  "createPartnerRegistrations"
+);
+
+const adminEmail = "admin@ubcbiztech.com";
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const snsMock = mockClient(SNSClient);
+
+const buildEvent = ({ email, body }) => ({
+  requestContext: {
+    authorizer: {
+      claims: {
+        email
+      }
+    }
+  },
+  body: JSON.stringify(body)
+});
+
+describe("registrationCreatePartnerRegistrations", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    snsMock.reset();
+  });
+
+  afterEach(() => {
+    ddbMock.restore();
+    snsMock.restore();
+  });
+
+  it("returns 403 when caller is not a BizTech admin", async () => {
+    const response = await wrapped.run(
+      buildEvent({
+        email: "student@gmail.com",
+        body: {
+          eventID: "kickstart",
+          year: 2025,
+          partners: []
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(403);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.message).to.equal("unauthorized");
+  });
+
+  it("returns 406 when eventID is not a string", async () => {
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          year: 2025,
+          partners: []
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(406);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.message).to.equal("eventID must be a string");
+  });
+
+  it("returns 406 when year is not a number", async () => {
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          eventID: "kickstart",
+          partners: []
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(406);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.message).to.equal("year must be a number");
+  });
+
+  it("returns 406 when partners is not an array", async () => {
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          eventID: "kickstart",
+          year: 2025
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(406);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.message).to.equal("partners must be an array");
+  });
+
+  it("marks invalid partner rows as failed", async () => {
+    ddbMock.on(GetCommand).callsFake((params) => {
+      if (
+        params.TableName.includes(EVENTS_TABLE) &&
+        params.Key.id === "kickstart" &&
+        params.Key.year === 2025
+      ) {
+        return {
+          Item: {
+            id: "kickstart",
+            year: 2025
+          }
+        };
+      }
+
+      return {
+        Item: null
+      };
+    });
+
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          eventID: "kickstart",
+          year: 2025,
+          partners: [
+            {
+              email: "not-an-email",
+              firstName: "Grace",
+              lastName: "Hopper"
+            }
+          ]
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(200);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.eventID).to.equal("kickstart");
+    expect(responseBody.year).to.equal(2025);
+    expect(responseBody.created).to.equal(0);
+    expect(responseBody.skipped).to.equal(0);
+    expect(responseBody.failed).to.equal(1);
+    expect(responseBody.results[0].email).to.equal("not-an-email");
+    expect(responseBody.results[0].status).to.equal("failed");
+    expect(responseBody.results[0].reason).to.equal("Invalid email");
+  });
+
+  it("returns 404 when the selected event does not exist", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: null
+    });
+
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          eventID: "missing-event",
+          year: 2025,
+          partners: []
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(404);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.message).to.equal(
+      "Event with id 'missing-event' and year '2025' could not be found."
+    );
+  });
+
+  it("skips partner rows when registration already exists", async () => {
+    const partnerEmail = "partner@example.com";
+
+    ddbMock.on(GetCommand).callsFake((params) => {
+      if (
+        params.TableName.includes(EVENTS_TABLE) &&
+        params.Key.id === "kickstart" &&
+        params.Key.year === 2025
+      ) {
+        return {
+          Item: {
+            id: "kickstart",
+            year: 2025
+          }
+        };
+      }
+
+      if (
+        params.TableName.includes(USER_REGISTRATIONS_TABLE) &&
+        params.Key.id === partnerEmail &&
+        params.Key["eventID;year"] === "kickstart;2025"
+      ) {
+        return {
+          Item: {
+            id: partnerEmail,
+            "eventID;year": "kickstart;2025"
+          }
+        };
+      }
+
+      return {
+        Item: null
+      };
+    });
+
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          eventID: "kickstart",
+          year: 2025,
+          partners: [
+            {
+              email: partnerEmail,
+              firstName: "Grace",
+              lastName: "Hopper"
+            }
+          ]
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(200);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.created).to.equal(0);
+    expect(responseBody.skipped).to.equal(1);
+    expect(responseBody.failed).to.equal(0);
+    expect(responseBody.results[0].email).to.equal(partnerEmail);
+    expect(responseBody.results[0].status).to.equal("skipped");
+    expect(responseBody.results[0].reason).to.equal(
+      "registration already exists"
+    );
+  });
+
+  it("creates a partner registration for a valid partner", async () => {
+    const partnerEmail = "partner@example.com";
+    let updateParams = null;
+
+    ddbMock.on(GetCommand).callsFake((params) => {
+      if (
+        params.TableName.includes(EVENTS_TABLE) &&
+        params.Key.id === "kickstart" &&
+        params.Key.year === 2025
+      ) {
+        return {
+          Item: {
+            id: "kickstart",
+            year: 2025,
+            capac: 100
+          }
+        };
+      }
+
+      return {
+        Item: null
+      };
+    });
+
+    ddbMock.on(UpdateCommand).callsFake((params) => {
+      updateParams = params;
+      return {
+        Attributes: {}
+      };
+    });
+
+    snsMock.on(PublishCommand).resolves({});
+
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          eventID: "kickstart",
+          year: 2025,
+          partners: [
+            {
+              email: partnerEmail,
+              firstName: "Katherine",
+              lastName: "Johnson"
+            }
+          ]
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(200);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.created).to.equal(1);
+    expect(responseBody.skipped).to.equal(0);
+    expect(responseBody.failed).to.equal(0);
+    expect(responseBody.results[0].email).to.equal(partnerEmail);
+    expect(responseBody.results[0].status).to.equal("created");
+
+    expect(updateParams.Key.id).to.equal(partnerEmail);
+    expect(updateParams.Key["eventID;year"]).to.equal("kickstart;2025");
+    expect(updateParams.ConditionExpression).to.equal(
+      "attribute_not_exists(id) and attribute_not_exists(#eventIDYear)"
+    );
+    expect(updateParams.ExpressionAttributeValues[":fname"]).to.equal(
+      "Katherine"
+    );
+    expect(updateParams.ExpressionAttributeValues[":registrationStatus"]).to.equal(
+      "acceptedComplete"
+    );
+    expect(updateParams.ExpressionAttributeValues[":isPartner"]).to.equal(true);
+  });
+
+  it("marks partner rows as failed when registration creation fails", async () => {
+    const partnerEmail = "partner@example.com";
+
+    ddbMock.on(GetCommand).callsFake((params) => {
+      if (
+        params.TableName.includes(EVENTS_TABLE) &&
+        params.Key.id === "kickstart" &&
+        params.Key.year === 2025
+      ) {
+        return {
+          Item: {
+            id: "kickstart",
+            year: 2025,
+            capac: 100
+          }
+        };
+      }
+
+      return {
+        Item: null
+      };
+    });
+
+    ddbMock.on(UpdateCommand).rejects({
+      statusCode: 500,
+      message: "Write failed"
+    });
+
+    snsMock.on(PublishCommand).resolves({});
+
+    const response = await wrapped.run(
+      buildEvent({
+        email: adminEmail,
+        body: {
+          eventID: "kickstart",
+          year: 2025,
+          partners: [
+            {
+              email: partnerEmail,
+              firstName: "Dorothy",
+              lastName: "Vaughan"
+            }
+          ]
+        }
+      })
+    );
+
+    expect(response.statusCode).to.equal(200);
+    const responseBody = JSON.parse(response.body);
+    expect(responseBody.created).to.equal(0);
+    expect(responseBody.skipped).to.equal(0);
+    expect(responseBody.failed).to.equal(1);
+    expect(responseBody.results[0].email).to.equal(partnerEmail);
+    expect(responseBody.results[0].status).to.equal("failed");
+    expect(responseBody.results[0].reason).to.not.be.empty;
+  });
+});


### PR DESCRIPTION
# Ticket(s):
Backend for # [UBC-43](https://linear.app/ubc-biztech/issue/UBC-43/partnership-ingestion-for-memberships-event-registrations), frontend coming soon

## **Context:**

Adds backend support for the partner CSV ingestion flow from the Manage Members admin page. Admins can create partner memberships, register partners for an event, or do both through frontend-selected options instead of relying on the old manual CLI script.

## **Changes:**
- Added `POST /members/partners/batch` for creating partner memberships.
- Added `POST /registrations/partners/batch` for registering partners to a selected event.
- Both endpoints are admin-only and return row-level `created`, `skipped`, and `failed` results.
- Membership creation skips partners already in `biztechMembers2026`.
- Event registration skips partners already registered for the selected `eventID/year`.

## **Notes:**
The existing Serverless unit test runner appears incompatible with Serverless v4, so the endpoint tests were run directly with Mocha for this PR.

## **Testing:**
- Added Mocha tests for auth, validation, duplicate skipping, successful creation, and row-level failure handling.
- Verified locally with direct Mocha workaround:
  - `memberCreatePartnerMemberships.js`: `6 passing`
  - `registrationCreatePartnerRegistrations.js`: `9 passing`
  - Curl tests: 
<img width="532" height="431" alt="image" src="https://github.com/user-attachments/assets/01a5732e-9435-4a84-9965-08b5e6ad2996" />


## **Wait! Before you merge, have you checked the following:**
- [ ] I have self-reviewed my code
- [ ] PR has approving review(s)